### PR TITLE
Fix #65

### DIFF
--- a/store/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
+++ b/store/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
@@ -401,8 +401,10 @@ public class GraphModelImpl implements GraphModel {
                     edgeTable.store.addColumn(new ColumnImpl(nodeTable, GraphStoreConfiguration.ELEMENT_TIMESET_COLUMN_ID, IntervalSet.class, "Interval", null, Origin.PROPERTY, false, false));
                     edgeTable.store.addColumn(new ColumnImpl(edgeTable, GraphStoreConfiguration.EDGE_WEIGHT_COLUMN_ID, IntervalDoubleMap.class, "Weight", null, Origin.PROPERTY, false, false));
                 }
+                
+                configuration.setTimeRepresentation(config.getTimeRepresentation());
+                store.initializeTimeStore();
             }
-            configuration.setTimeRepresentation(config.getTimeRepresentation());
             store.factory.resetConfiguration();
         } finally {
             store.autoWriteUnlock();

--- a/store/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/store/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -52,7 +52,7 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     protected final TableImpl<Node> nodeTable;
     protected final TableImpl<Edge> edgeTable;
     protected final GraphViewStore viewStore;
-    protected final TimeStore timeStore;
+    protected TimeStore timeStore;
     protected final GraphAttributesImpl attributes;
     //Factory
     protected final GraphFactoryImpl factory;
@@ -87,7 +87,7 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         nodeStore = new NodeStore(edgeStore, GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? lock : null, viewStore, GraphStoreConfiguration.ENABLE_OBSERVERS ? version : null);
         nodeTable = new TableImpl<Node>(configuration, Node.class, GraphStoreConfiguration.ENABLE_INDEX_NODES);
         edgeTable = new TableImpl<Edge>(configuration, Edge.class, GraphStoreConfiguration.ENABLE_INDEX_EDGES);
-        timeStore = new TimeStore(this, GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? lock : null, GraphStoreConfiguration.ENABLE_INDEX_TIMESTAMP);
+        initializeTimeStore();
         attributes = new GraphAttributesImpl();
         factory = new GraphFactoryImpl(this);
         timeFormat = GraphStoreConfiguration.DEFAULT_TIME_FORMAT;
@@ -116,6 +116,13 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         } else {
             edgeTable.store.addColumn(new ColumnImpl(edgeTable, GraphStoreConfiguration.EDGE_WEIGHT_COLUMN_ID, IntervalDoubleMap.class, "Weight", null, Origin.PROPERTY, false, false));
         }
+    }
+    
+    public final void initializeTimeStore(){
+        if(timeStore != null && !timeStore.isEmpty()){
+            throw new IllegalStateException("TimeStore is not empty, cannot initialize again");
+        }
+        timeStore = new TimeStore(this, GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? lock : null, GraphStoreConfiguration.ENABLE_INDEX_TIMESTAMP);
     }
 
     @Override

--- a/store/src/test/java/org/gephi/graph/impl/GraphModelTest.java
+++ b/store/src/test/java/org/gephi/graph/impl/GraphModelTest.java
@@ -35,6 +35,7 @@ import org.gephi.graph.api.TimeIndex;
 import org.joda.time.DateTimeZone;
 import org.gephi.graph.api.TimeRepresentation;
 import org.gephi.graph.api.types.IntervalSet;
+import org.gephi.graph.api.types.TimestampSet;
 
 public class GraphModelTest {
 
@@ -436,7 +437,7 @@ public class GraphModelTest {
     }
 
     @Test
-    public void testSetConfiguration() {
+    public void testSetConfigurationIntervals() {
         Configuration config = new Configuration();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
         config.setNodeIdType(Integer.class);
@@ -450,6 +451,27 @@ public class GraphModelTest {
         Assert.assertEquals(graphModelImpl.store.factory.edgeAssignConfiguration, GraphFactoryImpl.AssignConfiguration.DISABLED);
         Assert.assertEquals(graphModelImpl.getNodeTable().getColumn(GraphStoreConfiguration.ELEMENT_TIMESET_COLUMN_ID).getTypeClass(), IntervalSet.class);
         Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn(GraphStoreConfiguration.ELEMENT_TIMESET_COLUMN_ID).getTypeClass(), IntervalSet.class);
+        Assert.assertEquals(graphModelImpl.store.timeStore.nodeIndexStore.getClass(), IntervalIndexStore.class);
+        Assert.assertEquals(graphModelImpl.store.timeStore.edgeIndexStore.getClass(), IntervalIndexStore.class);
+    }
+    
+    @Test
+    public void testSetConfigurationTimestamps() {
+        Configuration config = new Configuration();
+        GraphModelImpl graphModelImpl = new GraphModelImpl(config);
+        config.setNodeIdType(Integer.class);
+        config.setEdgeIdType(Byte.class);
+        config.setTimeRepresentation(TimeRepresentation.TIMESTAMP);
+        graphModelImpl.setConfiguration(config);
+        Assert.assertEquals(graphModelImpl.getConfiguration(), config);
+        Assert.assertEquals(graphModelImpl.getNodeTable().getColumn("id").getTypeClass(), Integer.class);
+        Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn("id").getTypeClass(), Byte.class);
+        Assert.assertEquals(graphModelImpl.store.factory.nodeAssignConfiguration, GraphFactoryImpl.AssignConfiguration.INTEGER);
+        Assert.assertEquals(graphModelImpl.store.factory.edgeAssignConfiguration, GraphFactoryImpl.AssignConfiguration.DISABLED);
+        Assert.assertEquals(graphModelImpl.getNodeTable().getColumn(GraphStoreConfiguration.ELEMENT_TIMESET_COLUMN_ID).getTypeClass(), TimestampSet.class);
+        Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn(GraphStoreConfiguration.ELEMENT_TIMESET_COLUMN_ID).getTypeClass(), TimestampSet.class);
+        Assert.assertEquals(graphModelImpl.store.timeStore.nodeIndexStore.getClass(), TimestampIndexStore.class);
+        Assert.assertEquals(graphModelImpl.store.timeStore.edgeIndexStore.getClass(), TimestampIndexStore.class);
     }
 
     @Test(expectedExceptions = IllegalStateException.class)


### PR DESCRIPTION
TimeIndexStore is not updated when GraphModel.setConfiguration is called with a different TimeRepresentation

Had to make a field non final, so not sure if this is the best way of fixing it.