### PR TITLE
Add HierarchicalGraphView

### DIFF
--- a/store/src/main/java/org/gephi/graph/api/GraphModel.java
+++ b/store/src/main/java/org/gephi/graph/api/GraphModel.java
@@ -15,11 +15,12 @@
  */
 package org.gephi.graph.api;
 
+import org.gephi.graph.impl.GraphModelImpl;
+import org.joda.time.DateTimeZone;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import org.gephi.graph.impl.GraphModelImpl;
-import org.joda.time.DateTimeZone;
 
 /**
  * Graph API's entry point.
@@ -350,6 +351,13 @@ public interface GraphModel {
      * @return newly created graph view
      */
     public GraphView createView(boolean node, boolean edge);
+
+    /**
+     * Creates a new hierarchical graph view.
+     *
+     * @return newly created hierarchical graph view
+     */
+    public HierarchicalGraphView createHierarchicalView();
 
     /**
      * Creates a new graph view based on an existing view.

--- a/store/src/main/java/org/gephi/graph/api/HierarchicalGraphView.java
+++ b/store/src/main/java/org/gephi/graph/api/HierarchicalGraphView.java
@@ -1,0 +1,25 @@
+package org.gephi.graph.api;
+
+/**
+ * A hierarchical graph view which allows for collapsible sub-groups. Each node,
+ * whether it is collapsed or extended, should be in core in view. If a node is
+ * node is hidden by collapsed parent, it will omitted within
+ * directed/undirected graph queries.
+ */
+public interface HierarchicalGraphView extends GraphView {
+    /**
+     * @return Return iterator for each hierarchical node group.
+     */
+    Iterable<HierarchicalNodeGroup> getGroups();
+
+    /**
+     * @return Return root node which first-tier nodes should be attached.
+     */
+    HierarchicalNodeGroup getRoot();
+
+    /**
+     * @param node node within graph graph
+     * @return Return existing hierarchical group if available; else null.
+     */
+    HierarchicalNodeGroup getGroup(Node node);
+}

--- a/store/src/main/java/org/gephi/graph/api/HierarchicalNodeGroup.java
+++ b/store/src/main/java/org/gephi/graph/api/HierarchicalNodeGroup.java
@@ -1,0 +1,54 @@
+package org.gephi.graph.api;
+
+/**
+ * A group of nodes within a hierarchical graph view.
+ */
+public interface HierarchicalNodeGroup {
+    /**
+     * @return Returns true if the group is collapsed, which means the children
+     *         are hidden from visible graph.
+     */
+    boolean isCollapsed();
+
+    /**
+     * @return Returns true if the group is expanded, which means the children
+     *         are visible within visible graph.
+     */
+    boolean isExpanded();
+
+    /**
+     * Expand node, displaying children.
+     */
+    void expand();
+
+    /**
+     * Collapse node, hiding children.
+     */
+    void collapse();
+
+    /**
+     * @return Return iterator containing children nodes (not recursive).
+     */
+    Iterable<Node> getNodes();
+
+    /**
+     * @return Return iterator containing children nodes.
+     */
+    Iterable<Node> getNodes(boolean recursive);
+
+    /**
+     * Add node to this group.
+     *
+     * @param node child node
+     * @return Returns child hierarchical group, if created; else null.
+     */
+    HierarchicalNodeGroup addNode(Node node);
+
+    /**
+     * Remove node from group.
+     *
+     * @param node child node
+     * @return Returns true if child hierarchical group was remoce; else false.
+     */
+    boolean removeNode(Node node);
+}

--- a/store/src/main/java/org/gephi/graph/impl/AbstractGraphView.java
+++ b/store/src/main/java/org/gephi/graph/impl/AbstractGraphView.java
@@ -1,0 +1,105 @@
+package org.gephi.graph.impl;
+
+import org.gephi.graph.api.DirectedSubgraph;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphObserver;
+import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.Interval;
+import org.gephi.graph.api.UndirectedSubgraph;
+
+abstract public class AbstractGraphView implements GraphView {
+    protected final GraphStore graphStore;
+
+    protected final GraphAttributesImpl attributes;
+
+    protected final boolean nodeView;
+
+    protected final boolean edgeView;
+
+    private Interval interval;
+
+    private int storeId = GraphViewStore.NULL_VIEW;
+
+    public AbstractGraphView(final GraphStore store, boolean nodes, boolean edges) {
+        this.graphStore = store;
+        this.nodeView = nodes;
+        this.edgeView = edges;
+        this.interval = Interval.INFINITY_INTERVAL;
+        this.attributes = new GraphAttributesImpl();
+    }
+
+    public AbstractGraphView(final AbstractGraphView view, boolean nodes, boolean edges) {
+        this.graphStore = view.graphStore;
+        this.nodeView = nodes;
+        this.edgeView = edges;
+        this.interval = view.interval;
+        this.attributes = new GraphAttributesImpl();
+    }
+
+    public int getStoreId() {
+        return this.storeId;
+    }
+
+    protected void setStoreId(final int id) {
+        this.storeId = id;
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return GraphViewStore.NULL_VIEW == this.storeId;
+    }
+
+    @Override
+    public GraphModelImpl getGraphModel() {
+        return this.graphStore.graphModel;
+    }
+
+    @Override
+    public boolean isMainView() {
+        return false;
+    }
+
+    @Override
+    public boolean isNodeView() {
+        return this.nodeView;
+    }
+
+    @Override
+    public boolean isEdgeView() {
+        return this.edgeView;
+    }
+
+    public void setTimeInterval(Interval interval) {
+        if (interval == null) {
+            interval = Interval.INFINITY_INTERVAL;
+        }
+        this.interval = interval;
+    }
+
+    @Override
+    public Interval getTimeInterval() {
+        return this.interval;
+    }
+
+    abstract public DirectedSubgraph getDirectedGraph();
+
+    abstract public UndirectedSubgraph getUndirectedGraph();
+
+    abstract public boolean deepEquals(AbstractGraphView view);
+
+    abstract public int deepHashCode();
+
+    abstract protected void viewDestroyed();
+
+    abstract protected void nodeAdded(NodeImpl node);
+
+    abstract protected void nodeRemoved(NodeImpl node);
+
+    abstract protected void edgeAdded(EdgeImpl edge);
+
+    abstract protected void edgeRemoved(EdgeImpl edge);
+
+    abstract protected GraphObserverImpl createGraphObserver(Graph graph, boolean withDiff);
+
+    abstract protected void destroyGraphObserver(GraphObserver graphObserver);
+}

--- a/store/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
+++ b/store/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
@@ -16,6 +16,7 @@
 package org.gephi.graph.impl;
 
 import org.gephi.graph.api.Configuration;
+import org.gephi.graph.api.HierarchicalGraphView;
 import org.gephi.graph.api.Index;
 import org.gephi.graph.api.Table;
 import org.gephi.graph.api.TimeFormat;
@@ -236,6 +237,11 @@ public class GraphModelImpl implements GraphModel {
     @Override
     public GraphView createView(boolean node, boolean edge) {
         return store.viewStore.createView(node, edge);
+    }
+
+    @Override
+    public HierarchicalGraphView createHierarchicalView() {
+        return store.viewStore.createHierarchicalView();
     }
 
     @Override

--- a/store/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/store/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -15,16 +15,7 @@
  */
 package org.gephi.graph.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
 import org.gephi.graph.api.Configuration;
-import org.gephi.graph.api.Origin;
-import org.gephi.graph.api.TimeFormat;
-import org.gephi.graph.api.Interval;
-import org.gephi.graph.api.types.TimestampSet;
 import org.gephi.graph.api.DirectedGraph;
 import org.gephi.graph.api.DirectedSubgraph;
 import org.gephi.graph.api.Edge;
@@ -32,39 +23,66 @@ import org.gephi.graph.api.EdgeIterable;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphModel;
 import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.Interval;
 import org.gephi.graph.api.Node;
 import org.gephi.graph.api.NodeIterable;
+import org.gephi.graph.api.Origin;
 import org.gephi.graph.api.Subgraph;
-import org.joda.time.DateTimeZone;
+import org.gephi.graph.api.TimeFormat;
 import org.gephi.graph.api.TimeRepresentation;
 import org.gephi.graph.api.types.IntervalSet;
+import org.gephi.graph.api.types.TimestampSet;
+import org.joda.time.DateTimeZone;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 public class GraphStore implements DirectedGraph, DirectedSubgraph {
 
     protected final GraphModelImpl graphModel;
+
     protected final Configuration configuration;
+
     // Stores
     protected final NodeStore nodeStore;
+
     protected final EdgeStore edgeStore;
+
     protected final EdgeTypeStore edgeTypeStore;
+
     protected final TableImpl<Node> nodeTable;
+
     protected final TableImpl<Edge> edgeTable;
+
     protected final GraphViewStore viewStore;
+
     protected final TimeStore timeStore;
+
     protected final GraphAttributesImpl attributes;
+
     // Factory
     protected final GraphFactoryImpl factory;
+
     // Lock
     protected final GraphLock lock;
+
     // Version
     protected final GraphVersion version;
+
     protected final List<GraphObserverImpl> observers;
+
     // Undirected
     protected final UndirectedDecorator undirectedDecorator;
+
     // Main Graph view
     protected final GraphView mainGraphView;
+
     // TimeFormat
     protected TimeFormat timeFormat;
+
     // Time zone
     protected DateTimeZone timeZone;
 
@@ -822,6 +840,7 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     protected class NodeIterableWrapper implements NodeIterable {
 
         protected final Iterator<Node> iterator;
+
         protected final boolean blocking;
 
         public NodeIterableWrapper(Iterator<Node> iterator) {
@@ -842,7 +861,10 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         public Node[] toArray() {
             List<Node> list = new ArrayList<Node>();
             for (; iterator.hasNext();) {
-                list.add(iterator.next());
+                Node node = iterator.next();
+                if (node != null) {
+                    list.add(node);
+                }
             }
             return list.toArray(new Node[0]);
         }
@@ -851,7 +873,10 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         public Collection<Node> toCollection() {
             List<Node> list = new ArrayList<Node>();
             for (; iterator.hasNext();) {
-                list.add(iterator.next());
+                Node node = iterator.next();
+                if (node != null) {
+                    list.add(node);
+                }
             }
             return list;
         }
@@ -867,6 +892,7 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     protected class EdgeIterableWrapper implements EdgeIterable {
 
         protected final Iterator<Edge> iterator;
+
         protected final boolean blocking;
 
         public EdgeIterableWrapper(Iterator<Edge> iterator) {

--- a/store/src/main/java/org/gephi/graph/impl/GraphViewDecorator.java
+++ b/store/src/main/java/org/gephi/graph/impl/GraphViewDecorator.java
@@ -15,9 +15,6 @@
  */
 package org.gephi.graph.impl;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Set;
 import org.gephi.graph.api.DirectedSubgraph;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.EdgeIterable;
@@ -29,6 +26,10 @@ import org.gephi.graph.api.Node;
 import org.gephi.graph.api.NodeIterable;
 import org.gephi.graph.api.Subgraph;
 import org.gephi.graph.api.UndirectedSubgraph;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
 
 public class GraphViewDecorator implements DirectedSubgraph, UndirectedSubgraph {
 
@@ -736,10 +737,10 @@ public class GraphViewDecorator implements DirectedSubgraph, UndirectedSubgraph 
         if (view == null) {
             throw new NullPointerException();
         }
-        if (!(view instanceof GraphViewImpl)) {
-            throw new ClassCastException("Object must be a GraphViewImpl object");
+        if (!(view instanceof AbstractGraphView)) {
+            throw new ClassCastException("Object must be a AbstractGraphView object");
         }
-        if (((GraphViewImpl) view).graphStore != graphStore) {
+        if (((AbstractGraphView) view).graphStore != graphStore) {
             throw new RuntimeException("The view doesn't belong to this store");
         }
     }

--- a/store/src/main/java/org/gephi/graph/impl/HierarchicalGraphDecorator.java
+++ b/store/src/main/java/org/gephi/graph/impl/HierarchicalGraphDecorator.java
@@ -1,0 +1,1574 @@
+package org.gephi.graph.impl;
+
+import org.gephi.graph.api.Column;
+import org.gephi.graph.api.ColumnIterable;
+import org.gephi.graph.api.DirectedSubgraph;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.EdgeIterable;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.Interval;
+import org.gephi.graph.api.Node;
+import org.gephi.graph.api.NodeIterable;
+import org.gephi.graph.api.Subgraph;
+import org.gephi.graph.api.Table;
+import org.gephi.graph.api.TextProperties;
+import org.gephi.graph.api.UndirectedSubgraph;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+public class HierarchicalGraphDecorator implements DirectedSubgraph, UndirectedSubgraph {
+    private final boolean undirected;
+
+    private final HierarchicalGraphViewImpl view;
+
+    private final GraphStore graphStore;
+
+    public HierarchicalGraphDecorator(GraphStore graphStore, HierarchicalGraphViewImpl view, boolean undirected) {
+        this.graphStore = graphStore;
+        this.view = view;
+        this.undirected = undirected;
+    }
+
+    @Override
+    public Edge getEdge(Node node1, Node node2) {
+        graphStore.autoReadLock();
+        try {
+            for (final Node n1 : view.mapWithHidden(node1)) {
+                for (final Node n2 : view.mapWithHidden(node2)) {
+                    EdgeImpl edge = graphStore.edgeStore.get(n1, n2, undirected);
+                    if (edge != null && view.containsEdge(edge)) {
+                        return decorateEdge(edge);
+                    }
+                }
+            }
+            return null;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public Edge getEdge(Node node1, Node node2, int type) {
+        graphStore.autoReadLock();
+        try {
+            for (final Node n1 : view.mapWithHidden(node1)) {
+                for (final Node n2 : view.mapWithHidden(node2)) {
+                    EdgeImpl edge = graphStore.edgeStore.get(n1, n2, type, undirected);
+                    if (edge != null && view.containsEdge(edge)) {
+                        return decorateEdge(edge);
+                    }
+                }
+            }
+            return null;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public EdgeIterable getEdges(final Node node1, final Node node2) {
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n1 : view.mapWithHidden(node1)) {
+            for (final Node n2 : view.mapWithHidden(node2)) {
+                list.add(new Callable<Iterator<Edge>>() {
+                    @Override
+                    public Iterator<Edge> call() throws Exception {
+                        return graphStore.edgeStore.getAll(n1, n2, undirected);
+                    }
+                });
+            }
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public EdgeIterable getEdges(final Node node1, final Node node2, final int type) {
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n1 : view.mapWithHidden(node1)) {
+            for (final Node n2 : view.mapWithHidden(node2)) {
+                list.add(new Callable<Iterator<Edge>>() {
+                    @Override
+                    public Iterator<Edge> call() throws Exception {
+                        return graphStore.edgeStore.getAll(n1, n2, type, undirected);
+                    }
+                });
+            }
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public Edge getMutualEdge(Edge edge) {
+        graphStore.autoReadLock();
+        try {
+            final Edge unpacked = undecorateEdge(edge);
+            for (final Node n1 : view.mapWithHidden(unpacked.getSource())) {
+                for (final Node n2 : view.mapWithHidden(unpacked.getTarget())) {
+                    Edge e = graphStore.getEdge(n1, n2);
+                    EdgeImpl mutual = graphStore.edgeStore.getMutualEdge(e);
+                    if (mutual != null && view.containsEdge(mutual)) {
+                        return decorateEdge(mutual);
+                    }
+                }
+            }
+            return null;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public NodeIterable getPredecessors(Node node) {
+        checkValidInViewNodeObject(node);
+        return graphStore.getNodeIterableWrapper(new NeighborsIterator((NodeImpl) node, new EdgeViewIterator(
+                graphStore.edgeStore.edgeInIterator(node))));
+    }
+
+    @Override
+    public NodeIterable getPredecessors(Node node, int type) {
+        checkValidInViewNodeObject(node);
+        return graphStore.getNodeIterableWrapper(new NeighborsIterator((NodeImpl) node, new EdgeViewIterator(
+                graphStore.edgeStore.edgeInIterator(node, type))));
+    }
+
+    @Override
+    public NodeIterable getSuccessors(Node node) {
+        checkValidInViewNodeObject(node);
+        return graphStore.getNodeIterableWrapper(new NeighborsIterator((NodeImpl) node, new EdgeViewIterator(
+                graphStore.edgeStore.edgeOutIterator(node))));
+    }
+
+    @Override
+    public NodeIterable getSuccessors(Node node, int type) {
+        checkValidInViewNodeObject(node);
+        return graphStore.getNodeIterableWrapper(new NeighborsIterator((NodeImpl) node, new EdgeViewIterator(
+                graphStore.edgeStore.edgeOutIterator(node, type))));
+    }
+
+    @Override
+    public EdgeIterable getInEdges(Node node) {
+        checkValidInViewNodeObject(node);
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n : view.mapWithHidden(node)) {
+            list.add(new Callable<Iterator<Edge>>() {
+                @Override
+                public Iterator<Edge> call() throws Exception {
+                    return graphStore.edgeStore.edgeInIterator(n);
+                }
+            });
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public EdgeIterable getInEdges(final Node node, final int type) {
+        checkValidInViewNodeObject(node);
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n : view.mapWithHidden(node)) {
+            list.add(new Callable<Iterator<Edge>>() {
+                @Override
+                public Iterator<Edge> call() throws Exception {
+                    return graphStore.edgeStore.edgeInIterator(n, type);
+                }
+            });
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public EdgeIterable getOutEdges(final Node node) {
+        checkValidInViewNodeObject(node);
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n : view.mapWithHidden(node)) {
+            list.add(new Callable<Iterator<Edge>>() {
+                @Override
+                public Iterator<Edge> call() throws Exception {
+                    return graphStore.edgeStore.edgeOutIterator(n);
+                }
+            });
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public EdgeIterable getOutEdges(final Node node, final int type) {
+        checkValidInViewNodeObject(node);
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n : view.mapWithHidden(node)) {
+            list.add(new Callable<Iterator<Edge>>() {
+                @Override
+                public Iterator<Edge> call() throws Exception {
+                    return graphStore.edgeStore.edgeOutIterator(n, type);
+                }
+            });
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public boolean isAdjacent(Node source, Node target) {
+        checkValidInViewNodeObject(source);
+        checkValidInViewNodeObject(target);
+        graphStore.autoReadLock();
+        try {
+            for (final Node mappedSource : view.mapWithHidden(source)) {
+                for (final Node mappedTarget : view.mapWithHidden(target)) {
+                    EdgeImpl edge = graphStore.edgeStore.get(mappedSource, mappedTarget, undirected);
+                    if (edge != null && view.containsEdge(edge)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public boolean isAdjacent(Node source, Node target, int type) {
+        checkValidInViewNodeObject(source);
+        checkValidInViewNodeObject(target);
+        graphStore.autoReadLock();
+        try {
+            for (final Node mappedSource : view.mapWithHidden(source)) {
+                for (final Node mappedTarget : view.mapWithHidden(target)) {
+                    EdgeImpl edge = graphStore.edgeStore.get(mappedSource, mappedTarget, type, undirected);
+                    if (edge != null && view.containsEdge(edge)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public boolean addEdge(Edge edge) {
+        Edge unpacked = undecorateEdge(edge);
+        checkValidEdgeObject(unpacked);
+        graphStore.autoWriteLock();
+        try {
+            return view.addEdge(unpacked);
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean addNode(Node node) {
+        checkValidNodeObject(node);
+        graphStore.autoWriteLock();
+        try {
+            return view.addNode(node);
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean addAllEdges(Collection<? extends Edge> edges) {
+        graphStore.autoWriteLock();
+        try {
+            boolean updated = false;
+            for (final Edge edge : edges) {
+                updated |= view.addEdge(edge);
+            }
+            return updated;
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean addAllNodes(Collection<? extends Node> nodes) {
+        graphStore.autoWriteLock();
+        try {
+            boolean updated = false;
+            for (final Node node : nodes) {
+                updated |= view.addNode(node);
+            }
+            return updated;
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean removeEdge(Edge edge) {
+        Edge unpacked = undecorateEdge(edge);
+        checkValidEdgeObject(unpacked);
+        graphStore.autoWriteLock();
+        try {
+            return view.removeEdge(unpacked);
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean removeNode(Node node) {
+        checkValidNodeObject(node);
+        graphStore.autoWriteLock();
+        try {
+            return view.removeNode(node);
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean removeAllEdges(Collection<? extends Edge> edges) {
+        graphStore.autoWriteLock();
+        try {
+            return this.removeAllEdgesWithLock(edges.iterator());
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    private boolean removeAllEdgesWithLock(Iterator<? extends Edge> itr) {
+        if (null == itr) {
+            return false;
+        }
+
+        boolean updated = false;
+        while (itr.hasNext()) {
+            final Edge edge = itr.next();
+            if (edge != null) {
+                updated |= view.removeEdge(undecorateEdge(edge));
+            }
+        }
+        return updated;
+    }
+
+    @Override
+    public boolean removeAllNodes(Collection<? extends Node> nodes) {
+        graphStore.autoWriteLock();
+        try {
+            boolean updated = false;
+            for (final Node node : nodes) {
+                updated |= view.removeNode(node);
+            }
+            return updated;
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public boolean contains(Node node) {
+        checkValidNodeObject(node);
+        graphStore.autoReadLock();
+        try {
+            return view.containsNode((NodeImpl) node) && view.visibleNode((NodeImpl) node);
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public boolean contains(Edge edge) {
+        Edge unpacked = undecorateEdge(edge);
+        checkValidEdgeObject(unpacked);
+        graphStore.autoReadLock();
+        try {
+            return view.containsEdge((EdgeImpl) unpacked);
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public Node getNode(Object id) {
+        graphStore.autoReadLock();
+        try {
+            NodeImpl node = graphStore.getNode(id);
+            if (node != null && view.containsNode(node) && view.visibleNode(node)) {
+                return node;
+            }
+            return null;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public boolean hasNode(final Object id) {
+        return getNode(id) != null;
+    }
+
+    @Override
+    public Edge getEdge(Object id) {
+        graphStore.autoReadLock();
+        try {
+            EdgeImpl edge = graphStore.getEdge(id);
+            if (edge != null && view.containsEdge(edge)) {
+                return decorateEdge(edge);
+            }
+            return null;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public boolean hasEdge(final Object id) {
+        return getEdge(id) != null;
+    }
+
+    @Override
+    public NodeIterable getNodes() {
+        return graphStore.getNodeIterableWrapper(new NodeViewIterator(graphStore.nodeStore.iterator()));
+    }
+
+    @Override
+    public EdgeIterable getEdges() {
+        if (undirected) {
+            return graphStore.getEdgeIterableWrapper(new UndirectedEdgeViewIterator(graphStore.edgeStore.iterator()));
+        } else {
+            return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(graphStore.edgeStore.iterator()));
+        }
+    }
+
+    @Override
+    public EdgeIterable getSelfLoops() {
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(graphStore.edgeStore.iteratorSelfLoop()));
+    }
+
+    @Override
+    public NodeIterable getNeighbors(Node node) {
+        checkValidInViewNodeObject(node);
+        Set<Node> set = new HashSet<Node>();
+        for (final Node n : view.mapWithHidden(node)) {
+            final Iterator<Node> itr = new NeighborsIterator((NodeImpl) n, new UndirectedEdgeViewIterator(
+                    graphStore.edgeStore.edgeIterator(n)));
+            while (itr.hasNext()) {
+                final Node neighbor = itr.next();
+                if (neighbor != null) {
+                    set.add(neighbor);
+                }
+            }
+        }
+        checkValidInViewNodeObject(node);
+        return graphStore.getNodeIterableWrapper(new NodeViewIterator(set.iterator()));
+    }
+
+    @Override
+    public NodeIterable getNeighbors(Node node, int type) {
+        checkValidInViewNodeObject(node);
+        Set<Node> set = new HashSet<Node>();
+        for (final Node n : view.mapWithHidden(node)) {
+            final Iterator<Node> itr = new NeighborsIterator((NodeImpl) n, new UndirectedEdgeViewIterator(
+                    graphStore.edgeStore.edgeIterator(n, type)));
+            while (itr.hasNext()) {
+                final Node neighbor = itr.next();
+                if (neighbor != null) {
+                    set.add(neighbor);
+                }
+            }
+        }
+        checkValidInViewNodeObject(node);
+        return graphStore.getNodeIterableWrapper(new NodeViewIterator(set.iterator()));
+    }
+
+    @Override
+    public EdgeIterable getEdges(Node node) {
+        checkValidInViewNodeObject(node);
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n : view.mapWithHidden(node)) {
+            list.add(new Callable<Iterator<Edge>>() {
+                @Override
+                public Iterator<Edge> call() throws Exception {
+                    if (undirected) {
+                        return new UndirectedEdgeViewIterator(graphStore.edgeStore.edgeIterator(n));
+                    } else {
+                        return graphStore.edgeStore.edgeIterator(n);
+                    }
+                }
+            });
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public EdgeIterable getEdges(final Node node, final int type) {
+        checkValidInViewNodeObject(node);
+        List<Callable<Iterator<Edge>>> list = new ArrayList<Callable<Iterator<Edge>>>();
+        for (final Node n : view.mapWithHidden(node)) {
+            list.add(new Callable<Iterator<Edge>>() {
+                @Override
+                public Iterator<Edge> call() throws Exception {
+                    if (undirected) {
+                        return new UndirectedEdgeViewIterator(graphStore.edgeStore.edgeIterator(n, type));
+                    } else {
+                        return graphStore.edgeStore.edgeIterator(n, type);
+                    }
+                }
+            });
+        }
+        return graphStore.getEdgeIterableWrapper(new EdgeViewIterator(new ChainedFutureIterator<Edge>(list)));
+    }
+
+    @Override
+    public int getNodeCount() {
+        return view.getNodeCount();
+    }
+
+    @Override
+    public int getEdgeCount() {
+        if (undirected) {
+            return view.getUndirectedEdgeCount();
+        } else {
+            return view.getEdgeCount();
+        }
+    }
+
+    @Override
+    public int getEdgeCount(int type) {
+        if (undirected) {
+            return view.getUndirectedEdgeCount(type);
+        } else {
+            return view.getEdgeCount(type);
+        }
+    }
+
+    @Override
+    public Node getOpposite(Node node, Edge edge) {
+        Edge e = undecorateEdge(edge);
+        Node n1 = view.mapToVisible(e.getSource());
+        Node n2 = view.mapToVisible(e.getTarget());
+        checkValidInViewNodeObject(n1);
+        checkValidInViewNodeObject(n2);
+        checkValidInViewNodeObject(node);
+        checkValidInViewEdgeObject(e);
+        if (n1.equals(node)) {
+            return n2;
+        } else if (n2.equals(node)) {
+            return n1;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public int getDegree(final Node node) {
+        if (!this.contains(node)) {
+            return 0;
+        }
+
+        if (undirected) {
+            int count = 0;
+            for (final Node related : view.mapWithHidden(node)) {
+                EdgeStore.EdgeInOutIterator itr = graphStore.edgeStore.edgeIterator(related);
+                while (itr.hasNext()) {
+                    EdgeImpl edge = itr.next();
+                    if (view.containsEdge(edge) && !isUndirectedToIgnore(edge)) {
+                        count++;
+                        if (edge.isSelfLoop()) {
+                            count++;
+                        }
+                    }
+                }
+            }
+            return count;
+        } else {
+            int count = 0;
+            for (final Node related : view.mapWithHidden(node)) {
+                EdgeStore.EdgeInOutIterator itr = graphStore.edgeStore.edgeIterator(related);
+                while (itr.hasNext()) {
+                    EdgeImpl edge = itr.next();
+                    if (view.containsEdge(edge)) {
+                        count++;
+                        if (edge.isSelfLoop()) {
+                            count++;
+                        }
+                    }
+                }
+            }
+            return count;
+        }
+    }
+
+    @Override
+    public int getInDegree(final Node node) {
+        if (!this.contains(node)) {
+            return 0;
+        }
+
+        int count = 0;
+        for (final Node related : view.mapWithHidden(node)) {
+            EdgeStore.EdgeInIterator itr = graphStore.edgeStore.edgeInIterator(related);
+            while (itr.hasNext()) {
+                if (view.containsEdge(itr.next())) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public int getOutDegree(final Node node) {
+        if (!this.contains(node)) {
+            return 0;
+        }
+
+        int count = 0;
+        for (final Node related : view.mapWithHidden(node)) {
+            EdgeStore.EdgeOutIterator itr = graphStore.edgeStore.edgeOutIterator(related);
+            while (itr.hasNext()) {
+                if (view.containsEdge(itr.next())) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public boolean isSelfLoop(Edge edge) {
+        return edge.isSelfLoop();
+    }
+
+    @Override
+    public boolean isDirected(Edge edge) {
+        return edge.isDirected();
+    }
+
+    @Override
+    public boolean isIncident(Edge edge1, Edge edge2) {
+        graphStore.autoReadLock();
+        try {
+            if (edge1 instanceof MappedEdgeDecorator) {
+                edge1 = undecorateEdge(edge1);
+            } else {
+                edge1 = decorateEdge(edge1);
+            }
+
+            if (edge2 instanceof MappedEdgeDecorator) {
+                edge2 = undecorateEdge(edge2);
+            } else {
+                edge2 = decorateEdge(edge2);
+            }
+
+            Set<Node> n1 = new HashSet<Node>();
+            for (final Node n : Arrays.asList(edge1.getSource(), edge1.getTarget())) {
+                n1.addAll(view.mapWithHidden(n));
+            }
+
+            Set<Node> n2 = new HashSet<Node>();
+            for (final Node n : Arrays.asList(edge2.getSource(), edge2.getTarget())) {
+                n2.addAll(view.mapWithHidden(n));
+            }
+
+            for (Node n : n1) {
+                if (n2.contains(n)) {
+                    return true;
+                }
+            }
+
+            for (Node n : n2) {
+                if (n1.contains(n)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public boolean isIncident(Node node, Edge edge) {
+        graphStore.autoReadLock();
+        try {
+            if (edge instanceof MappedEdgeDecorator) {
+                edge = undecorateEdge(edge);
+            } else {
+                edge = decorateEdge(edge);
+            }
+
+            Set<Node> n1 = new HashSet<Node>();
+            for (final Node n : Arrays.asList(edge.getSource(), edge.getTarget())) {
+                n1.addAll(view.mapWithHidden(n));
+            }
+
+            Set<Node> n2 = new HashSet<Node>(view.mapWithHidden(node));
+
+            for (Node n : n1) {
+                if (n2.contains(n)) {
+                    return true;
+                }
+            }
+
+            for (Node n : n2) {
+                if (n1.contains(n)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } finally {
+            graphStore.autoReadUnlock();
+        }
+    }
+
+    @Override
+    public void clearEdges(final Node node) {
+        graphStore.autoWriteLock();
+        try {
+            this.removeAllEdgesWithLock(graphStore.edgeStore.edgeIterator(node));
+            for (final Node related : view.mapWithHidden(node)) {
+                this.removeAllEdgesWithLock(graphStore.edgeStore.edgeIterator(related));
+            }
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public void clearEdges(final Node node, final int type) {
+        graphStore.autoWriteLock();
+        try {
+            this.removeAllEdgesWithLock(graphStore.edgeStore.edgeIterator(node, type));
+            for (final Node related : view.mapWithHidden(node)) {
+                this.removeAllEdgesWithLock(graphStore.edgeStore.edgeIterator(related, type));
+            }
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public void clear() {
+        view.clear();
+    }
+
+    @Override
+    public void clearEdges() {
+        view.clearEdges();
+    }
+
+    @Override
+    public Object getAttribute(String key) {
+        return view.attributes.getValue(key);
+    }
+
+    @Override
+    public Object getAttribute(String key, double timestamp) {
+        return view.attributes.getValue(key, timestamp);
+    }
+
+    @Override
+    public Object getAttribute(String key, Interval interval) {
+        return view.attributes.getValue(key, interval);
+    }
+
+    @Override
+    public Set<String> getAttributeKeys() {
+        return view.attributes.getKeys();
+    }
+
+    @Override
+    public void setAttribute(String key, Object value) {
+        view.attributes.setValue(key, value);
+    }
+
+    @Override
+    public void setAttribute(String key, Object value, double timestamp) {
+        view.attributes.setValue(key, value, timestamp);
+    }
+
+    @Override
+    public void setAttribute(String key, Object value, Interval interval) {
+        view.attributes.setValue(key, value, interval);
+    }
+
+    @Override
+    public void removeAttribute(String key) {
+        view.attributes.removeValue(key);
+    }
+
+    @Override
+    public void removeAttribute(String key, double timestamp) {
+        view.attributes.removeValue(key, timestamp);
+    }
+
+    @Override
+    public void removeAttribute(String key, Interval interval) {
+        view.attributes.removeValue(key, interval);
+    }
+
+    @Override
+    public GraphModel getModel() {
+        return graphStore.graphModel;
+    }
+
+    @Override
+    public boolean isDirected() {
+        return graphStore.isDirected();
+    }
+
+    @Override
+    public boolean isUndirected() {
+        return graphStore.isUndirected();
+    }
+
+    @Override
+    public boolean isMixed() {
+        return graphStore.isMixed();
+    }
+
+    @Override
+    public void readLock() {
+        graphStore.lock.readLock();
+    }
+
+    @Override
+    public void readUnlock() {
+        graphStore.lock.readUnlock();
+    }
+
+    @Override
+    public void readUnlockAll() {
+        graphStore.lock.readUnlockAll();
+    }
+
+    @Override
+    public void writeLock() {
+        graphStore.lock.writeLock();
+    }
+
+    @Override
+    public void writeUnlock() {
+        graphStore.lock.writeUnlock();
+    }
+
+    @Override
+    public GraphView getView() {
+        return view;
+    }
+
+    @Override
+    public void fill() {
+        graphStore.autoWriteLock();
+        try {
+            view.fill();
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public void union(final Subgraph subGraph) {
+        checkValidViewObject(subGraph.getView());
+
+        graphStore.autoWriteLock();
+        try {
+            if (subGraph instanceof GraphViewDecorator) {
+                view.viewDelegate.union((GraphViewImpl) subGraph.getView());
+            } else if (subGraph instanceof HierarchicalGraphDecorator) {
+                final HierarchicalGraphViewImpl other = (HierarchicalGraphViewImpl) subGraph.getView();
+                view.viewDelegate.union(other.viewDelegate);
+            }
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public void intersection(final Subgraph subGraph) {
+        checkValidViewObject(subGraph.getView());
+
+        graphStore.autoWriteLock();
+        try {
+            if (subGraph instanceof GraphViewDecorator) {
+                view.viewDelegate.intersection((GraphViewImpl) subGraph.getView());
+            } else if (subGraph instanceof HierarchicalGraphDecorator) {
+                final HierarchicalGraphViewImpl other = (HierarchicalGraphViewImpl) subGraph.getView();
+                view.viewDelegate.intersection(other.viewDelegate);
+            }
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public void not() {
+        graphStore.autoWriteLock();
+        try {
+            view.not();
+        } finally {
+            graphStore.autoWriteUnlock();
+        }
+    }
+
+    @Override
+    public Graph getRootGraph() {
+        return graphStore;
+    }
+
+    void checkWriteLock() {
+        if (graphStore.lock != null) {
+            graphStore.lock.checkHoldWriteLock();
+        }
+    }
+
+    void checkValidNodeObject(final Node n) {
+        if (n == null) {
+            throw new NullPointerException();
+        }
+        if (!(n instanceof NodeImpl)) {
+            throw new ClassCastException("Object must be a NodeImpl object");
+        }
+        if (((NodeImpl) n).storeId == NodeStore.NULL_ID) {
+            throw new IllegalArgumentException("Node should belong to a store");
+        }
+    }
+
+    void checkValidInViewNodeObject(final Node n) {
+        checkValidNodeObject(n);
+
+        if (!view.containsNode((NodeImpl) n)) {
+            throw new RuntimeException("Node doesn't belong to this view");
+        }
+    }
+
+    void checkValidEdgeObject(final Edge e) {
+        if (e == null) {
+            throw new NullPointerException();
+        }
+        if (!(e instanceof EdgeImpl)) {
+            throw new ClassCastException("Object must be a EdgeImpl object");
+        }
+        if (((EdgeImpl) e).storeId == EdgeStore.NULL_ID) {
+            throw new IllegalArgumentException("Edge should belong to a store");
+        }
+    }
+
+    void checkValidInViewEdgeObject(final Edge e) {
+        checkValidEdgeObject(e);
+        if (!view.containsEdge((EdgeImpl) e)) {
+            throw new RuntimeException("Edge doesn't belong to this view");
+        }
+    }
+
+    void checkValidViewObject(final GraphView view) {
+        if (view == null) {
+            throw new NullPointerException();
+        }
+        if (!(view instanceof AbstractGraphView)) {
+            throw new ClassCastException("Object must be a AbstractGraphView object");
+        }
+        if (((AbstractGraphView) view).graphStore != graphStore) {
+            throw new RuntimeException("The view doesn't belong to this store");
+        }
+    }
+
+    boolean isUndirectedToIgnore(final EdgeImpl edge) {
+        if (edge.isMutual() && edge.source.storeId < edge.target.storeId) {
+            if (view.containsEdge(graphStore.edgeStore.get(edge.target, edge.source, edge.type, false))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private final class ChainedFutureIterator<T> implements Iterator<T> {
+        private final List<Callable<Iterator<T>>> delegates;
+
+        private Iterator<Callable<Iterator<T>>> itr = null;
+
+        private Iterator<T> delegatePointer = null;
+
+        private T itemPointer = null;
+
+        private ChainedFutureIterator(final Collection<? extends Callable<Iterator<T>>> c) {
+            this.delegates = new ArrayList<Callable<Iterator<T>>>(c);
+        }
+
+        @Override
+        public boolean hasNext() {
+            itemPointer = null;
+
+            if (null == this.itr) {
+                itr = delegates.iterator();
+            }
+
+            while (null == itemPointer) {
+                while (null == delegatePointer) {
+                    if (!itr.hasNext()) {
+                        return false;
+                    }
+                    try {
+                        delegatePointer = itr.next().call();
+                    } catch (final Exception e) {
+                        throw new IllegalStateException(e);
+                    }
+                }
+
+                if (delegatePointer.hasNext()) {
+                    itemPointer = delegatePointer.next();
+                } else {
+                    delegatePointer = null;
+                }
+            }
+
+            return true;
+        }
+
+        @Override
+        public T next() {
+            return itemPointer;
+        }
+    }
+
+    private final class NodeViewIterator implements Iterator<Node> {
+        private final Iterator<Node> nodeIterator;
+
+        private NodeImpl pointer;
+
+        public NodeViewIterator(Iterator<Node> nodeIterator) {
+            this.nodeIterator = nodeIterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            pointer = null;
+            while (pointer == null) {
+                if (!nodeIterator.hasNext()) {
+                    return false;
+                }
+                pointer = (NodeImpl) nodeIterator.next();
+                if (pointer != null) {
+                    if (!view.containsNode(pointer) || !view.visibleNode(pointer)) {
+                        pointer = null;
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public Node next() {
+            return pointer;
+        }
+
+        @Override
+        public void remove() {
+            checkWriteLock();
+            removeNode(pointer);
+        }
+    }
+
+    private final class EdgeViewIterator implements Iterator<Edge> {
+        private final Iterator<Edge> edgeIterator;
+
+        private EdgeImpl pointer;
+
+        public EdgeViewIterator(Iterator<Edge> edgeIterator) {
+            this.edgeIterator = edgeIterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            pointer = null;
+            while (pointer == null) {
+                if (!edgeIterator.hasNext()) {
+                    return false;
+                }
+                pointer = (EdgeImpl) edgeIterator.next();
+                if (pointer != null) {
+                    if (!view.containsEdge(pointer)) {
+                        pointer = null;
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public Edge next() {
+            return decorateEdge(pointer);
+        }
+
+        @Override
+        public void remove() {
+            checkWriteLock();
+            removeEdge(pointer);
+        }
+    }
+
+    private final class UndirectedEdgeViewIterator implements Iterator<Edge> {
+        private final Iterator<Edge> itr;
+
+        private EdgeImpl pointer;
+
+        public UndirectedEdgeViewIterator(Iterator<Edge> itr) {
+            this.itr = itr;
+        }
+
+        @Override
+        public boolean hasNext() {
+            pointer = null;
+            while (pointer == null || !view.containsEdge(pointer) || isUndirectedToIgnore(pointer)) {
+                if (!itr.hasNext()) {
+                    return false;
+                }
+                pointer = (EdgeImpl) itr.next();
+            }
+            return true;
+        }
+
+        @Override
+        public Edge next() {
+            return decorateEdge(pointer);
+        }
+
+        @Override
+        public void remove() {
+            itr.remove();
+        }
+    }
+
+    private class NeighborsIterator implements Iterator<Node> {
+        private final NodeImpl node;
+
+        private final Iterator<Edge> itr;
+
+        public NeighborsIterator(NodeImpl node, Iterator<Edge> itr) {
+            this.node = node;
+            this.itr = itr;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return itr.hasNext();
+        }
+
+        @Override
+        public Node next() {
+            Edge e = itr.next();
+            return e.getSource() == node ? e.getTarget() : e.getSource();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("Remove not supported for this iterator");
+        }
+    }
+
+    private Edge undecorateEdge(final Edge edge) {
+        if (null == edge) {
+            return null;
+        }
+
+        Edge unpacked = edge;
+        while (unpacked instanceof MappedEdgeDecorator) {
+            unpacked = ((MappedEdgeDecorator) unpacked).edge;
+        }
+
+        return unpacked;
+    }
+
+    private Edge decorateEdge(final Edge edge) {
+        if (null == edge) {
+            return null;
+        }
+
+        if (edge instanceof MappedEdgeDecorator) {
+            return edge;
+        }
+
+        final Node mappedSource = this.view.mapToVisible(edge.getSource());
+        final Node mappedTarget = this.view.mapToVisible(edge.getTarget());
+
+        if (mappedSource == edge.getSource() && mappedTarget == edge.getTarget()) {
+            return edge;
+        }
+
+        return new MappedEdgeDecorator(edge, mappedSource, mappedTarget);
+    }
+
+    protected class MappedEdgeDecorator implements Edge {
+        private final Edge edge;
+
+        private final Node source;
+
+        private final Node target;
+
+        private MappedEdgeDecorator(final Edge edge, final Node source, final Node target) {
+            this.edge = edge;
+            this.source = source;
+            this.target = target;
+        }
+
+        @Override
+        public Node getSource() {
+            return this.source;
+        }
+
+        @Override
+        public Node getTarget() {
+            return this.target;
+        }
+
+        @Override
+        public double getWeight() {
+            return edge.getWeight();
+        }
+
+        @Override
+        public double getWeight(double timestamp) {
+            return edge.getWeight(timestamp);
+        }
+
+        @Override
+        public double getWeight(Interval interval) {
+            return edge.getWeight(interval);
+        }
+
+        @Override
+        public double getWeight(GraphView view) {
+            return edge.getWeight(view);
+        }
+
+        @Override
+        public Iterable<Map.Entry> getWeights() {
+            return edge.getWeights();
+        }
+
+        @Override
+        public void setWeight(double weight) {
+            edge.setWeight(weight);
+        }
+
+        @Override
+        public void setWeight(double weight, double timestamp) {
+            edge.setWeight(weight, timestamp);
+        }
+
+        @Override
+        public void setWeight(double weight, Interval interval) {
+            edge.setWeight(weight, interval);
+        }
+
+        @Override
+        public boolean hasDynamicWeight() {
+            return edge.hasDynamicWeight();
+        }
+
+        @Override
+        public int getType() {
+            return edge.getType();
+        }
+
+        @Override
+        public Object getTypeLabel() {
+            return edge.getTypeLabel();
+        }
+
+        @Override
+        public boolean isSelfLoop() {
+            return edge.isSelfLoop();
+        }
+
+        @Override
+        public boolean isDirected() {
+            return edge.isSelfLoop();
+        }
+
+        @Override
+        public Object getId() {
+            return edge.getId();
+        }
+
+        @Override
+        public String getLabel() {
+            return edge.getLabel();
+        }
+
+        @Override
+        public Object getAttribute(String key) {
+            return edge.getAttribute(key);
+        }
+
+        @Override
+        public Object getAttribute(Column column) {
+            return edge.getAttribute(column);
+        }
+
+        @Override
+        public Object getAttribute(String key, double timestamp) {
+            return edge.getAttribute(key, timestamp);
+        }
+
+        @Override
+        public Object getAttribute(Column column, double timestamp) {
+            return edge.getAttribute(column, timestamp);
+        }
+
+        @Override
+        public Object getAttribute(String key, Interval interval) {
+            return edge.getAttribute(key, interval);
+        }
+
+        @Override
+        public Object getAttribute(Column column, Interval interval) {
+            return edge.getAttribute(column, interval);
+        }
+
+        @Override
+        public Object getAttribute(String key, GraphView view) {
+            return edge.getAttribute(key, view);
+        }
+
+        @Override
+        public Object getAttribute(Column column, GraphView view) {
+            return edge.getAttribute(column, view);
+        }
+
+        @Override
+        public Iterable<Map.Entry> getAttributes(Column column) {
+            return edge.getAttributes(column);
+        }
+
+        @Override
+        public Object[] getAttributes() {
+            return edge.getAttributes();
+        }
+
+        @Override
+        public Set<String> getAttributeKeys() {
+            return edge.getAttributeKeys();
+        }
+
+        @Override
+        public ColumnIterable getAttributeColumns() {
+            return edge.getAttributeColumns();
+        }
+
+        @Override
+        public int getStoreId() {
+            return edge.getStoreId();
+        }
+
+        @Override
+        public Object removeAttribute(String key) {
+            return edge.removeAttribute(key);
+        }
+
+        @Override
+        public Object removeAttribute(Column column) {
+            return edge.removeAttribute(column);
+        }
+
+        @Override
+        public Object removeAttribute(String key, double timestamp) {
+            return edge.removeAttribute(key, timestamp);
+        }
+
+        @Override
+        public Object removeAttribute(Column column, double timestamp) {
+            return edge.removeAttribute(column, timestamp);
+        }
+
+        @Override
+        public Object removeAttribute(String key, Interval interval) {
+            return edge.removeAttribute(key, interval);
+        }
+
+        @Override
+        public Object removeAttribute(Column column, Interval interval) {
+            return edge.removeAttribute(column, interval);
+        }
+
+        @Override
+        public void setLabel(String label) {
+            edge.setLabel(label);
+        }
+
+        @Override
+        public void setAttribute(String key, Object value) {
+            edge.setAttribute(key, value);
+        }
+
+        @Override
+        public void setAttribute(Column column, Object value) {
+            edge.setAttribute(column, value);
+        }
+
+        @Override
+        public void setAttribute(String key, Object value, double timestamp) {
+            edge.setAttribute(key, value, timestamp);
+        }
+
+        @Override
+        public void setAttribute(Column column, Object value, double timestamp) {
+            edge.setAttribute(column, value, timestamp);
+        }
+
+        @Override
+        public void setAttribute(String key, Object value, Interval interval) {
+            edge.setAttribute(key, value, interval);
+        }
+
+        @Override
+        public void setAttribute(Column column, Object value, Interval interval) {
+            edge.setAttribute(column, value, interval);
+        }
+
+        @Override
+        public boolean addTimestamp(double timestamp) {
+            return edge.addTimestamp(timestamp);
+        }
+
+        @Override
+        public boolean removeTimestamp(double timestamp) {
+            return edge.removeTimestamp(timestamp);
+        }
+
+        @Override
+        public boolean hasTimestamp(double timestamp) {
+            return edge.hasTimestamp(timestamp);
+        }
+
+        @Override
+        public double[] getTimestamps() {
+            return edge.getTimestamps();
+        }
+
+        @Override
+        public boolean addInterval(Interval interval) {
+            return edge.addInterval(interval);
+        }
+
+        @Override
+        public boolean removeInterval(Interval interval) {
+            return edge.removeInterval(interval);
+        }
+
+        @Override
+        public boolean hasInterval(Interval interval) {
+            return edge.hasInterval(interval);
+        }
+
+        @Override
+        public Interval[] getIntervals() {
+            return edge.getIntervals();
+        }
+
+        @Override
+        public void clearAttributes() {
+            edge.clearAttributes();
+        }
+
+        @Override
+        public Table getTable() {
+            return edge.getTable();
+        }
+
+        @Override
+        public float r() {
+            return edge.r();
+        }
+
+        @Override
+        public float g() {
+            return edge.g();
+        }
+
+        @Override
+        public float b() {
+            return edge.b();
+        }
+
+        @Override
+        public int getRGBA() {
+            return edge.getRGBA();
+        }
+
+        @Override
+        public Color getColor() {
+            return edge.getColor();
+        }
+
+        @Override
+        public float alpha() {
+            return edge.alpha();
+        }
+
+        @Override
+        public TextProperties getTextProperties() {
+            return edge.getTextProperties();
+        }
+
+        @Override
+        public void setR(float r) {
+            edge.setR(r);
+        }
+
+        @Override
+        public void setG(float g) {
+            edge.setG(g);
+        }
+
+        @Override
+        public void setB(float b) {
+            edge.setB(b);
+        }
+
+        @Override
+        public void setAlpha(float a) {
+            edge.setAlpha(a);
+        }
+
+        @Override
+        public void setColor(Color color) {
+            edge.setColor(color);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            MappedEdgeDecorator that = (MappedEdgeDecorator) o;
+
+            if (edge != null ? !edge.equals(that.edge) : that.edge != null) {
+                return false;
+            }
+            if (source != null ? !source.equals(that.source) : that.source != null) {
+                return false;
+            }
+            return target != null ? target.equals(that.target) : that.target == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = edge != null ? edge.hashCode() : 0;
+            result = 31 * result + (source != null ? source.hashCode() : 0);
+            result = 31 * result + (target != null ? target.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/store/src/main/java/org/gephi/graph/impl/HierarchicalGraphViewImpl.java
+++ b/store/src/main/java/org/gephi/graph/impl/HierarchicalGraphViewImpl.java
@@ -1,0 +1,513 @@
+package org.gephi.graph.impl;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.gephi.graph.api.DirectedSubgraph;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphObserver;
+import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.HierarchicalGraphView;
+import org.gephi.graph.api.HierarchicalNodeGroup;
+import org.gephi.graph.api.Node;
+import org.gephi.graph.api.UndirectedSubgraph;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class HierarchicalGraphViewImpl extends AbstractGraphView implements GraphView, HierarchicalGraphView {
+    protected final GraphViewImpl viewDelegate;
+
+    private final GraphVersion version;
+
+    private final HierarchicalGraphDecorator directedDecorator;
+
+    private final HierarchicalGraphDecorator undirectedDecorator;
+
+    private final Set<GraphObserverImpl> observers = new HashSet<GraphObserverImpl>();
+
+    private final HierarchicalNodeGroupImpl root = new HierarchicalNodeGroupImpl(null, null);
+
+    public HierarchicalGraphViewImpl(GraphStore store, boolean nodes, boolean edges) {
+        super(store, nodes, edges);
+        this.viewDelegate = new GraphViewImpl(store, nodes, edges);
+        this.directedDecorator = new HierarchicalGraphDecorator(store, this, false);
+        this.undirectedDecorator = new HierarchicalGraphDecorator(store, this, true);
+        this.version = graphStore.version != null ? new GraphVersion(directedDecorator) : null;
+    }
+
+    public boolean containsNode(final NodeImpl node) {
+        if (null == node) {
+            return false;
+        }
+
+        if (!this.viewDelegate.containsNode(node)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean visibleNode(final NodeImpl node) {
+        if (null == node) {
+            return false;
+        }
+
+        final Node mapped = this.mapToVisible(node);
+        if (null == mapped) {
+            return false;
+        }
+
+        return mapped == node;
+    }
+
+    public boolean addNode(final Node node) {
+        if (!this.viewDelegate.addNode(node)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean removeNode(final Node node) {
+        boolean updated = this.viewDelegate.removeNode(node);
+        updated |= this.root.removeNode(node, true);
+        return updated;
+    }
+
+    public boolean addEdge(final Edge edge) {
+        if (!this.viewDelegate.addEdge(edge)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean removeEdge(final Edge edge) {
+        if (!this.viewDelegate.removeEdge(edge)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean containsEdge(final EdgeImpl edge) {
+        return this.viewDelegate.containsEdge(edge);
+    }
+
+    public int getCollapsedNodeCount() {
+        final Set<HierarchicalNodeGroupImpl> visibleGroups = new HashSet<HierarchicalNodeGroupImpl>();
+        final Set<HierarchicalNodeGroupImpl> hiddenGroups = new HashSet<HierarchicalNodeGroupImpl>();
+        for (final HierarchicalNodeGroup group : this.getGroups()) {
+            final HierarchicalNodeGroupImpl impl = (HierarchicalNodeGroupImpl) group;
+            if (impl.hasCollapsedParent()) {
+                hiddenGroups.add(impl);
+                visibleGroups.remove(impl);
+            } else if (!hiddenGroups.contains(impl)) {
+                visibleGroups.add(impl);
+            }
+        }
+        return hiddenGroups.size();
+    }
+
+    public int getNodeCount() {
+        return this.viewDelegate.getNodeCount() - this.getCollapsedNodeCount();
+    }
+
+    public int getEdgeCount() {
+        return this.viewDelegate.getEdgeCount();
+    }
+
+    public int getEdgeCount(int type) {
+        return this.viewDelegate.getEdgeCount(type);
+    }
+
+    public int getUndirectedEdgeCount() {
+        return this.viewDelegate.getUndirectedEdgeCount();
+    }
+
+    public int getUndirectedEdgeCount(int type) {
+        return this.viewDelegate.getUndirectedEdgeCount(type);
+    }
+
+    public void clear() {
+        this.root.clear();
+        this.viewDelegate.clear();
+    }
+
+    public void clearEdges() {
+        this.viewDelegate.clearEdges();
+    }
+
+    public void fill() {
+        this.viewDelegate.fill();
+    }
+
+    public void not() {
+        this.viewDelegate.not();
+    }
+
+    @Override
+    public DirectedSubgraph getDirectedGraph() {
+        return this.directedDecorator;
+    }
+
+    @Override
+    public UndirectedSubgraph getUndirectedGraph() {
+        return this.undirectedDecorator;
+    }
+
+    @Override
+    public boolean deepEquals(AbstractGraphView view) {
+        return this.viewDelegate.deepEquals(view);
+    }
+
+    @Override
+    public int deepHashCode() {
+        return this.viewDelegate.deepHashCode();
+    }
+
+    @Override
+    protected void viewDestroyed() {
+        this.setStoreId(GraphViewStore.NULL_VIEW);
+        for (final GraphObserverImpl observer : this.observers) {
+            observer.destroyObserver();
+        }
+        this.observers.clear();
+        this.root.clear();
+        this.viewDelegate.viewDestroyed();
+    }
+
+    @Override
+    protected void nodeAdded(NodeImpl node) {
+        this.viewDelegate.nodeAdded(node);
+    }
+
+    @Override
+    protected void nodeRemoved(NodeImpl node) {
+        this.removeNode(node);
+        this.viewDelegate.nodeRemoved(node);
+    }
+
+    @Override
+    protected void edgeAdded(EdgeImpl edge) {
+        this.viewDelegate.edgeAdded(edge);
+    }
+
+    @Override
+    protected void edgeRemoved(EdgeImpl edge) {
+        this.viewDelegate.edgeRemoved(edge);
+    }
+
+    @Override
+    protected GraphObserverImpl createGraphObserver(final Graph graph, final boolean withDiff) {
+        if (null == this.version) {
+            return null;
+        }
+
+        final GraphObserverImpl observer = new GraphObserverImpl(this.graphStore, this.version, graph, withDiff);
+        this.observers.add(observer);
+        return observer;
+    }
+
+    @Override
+    protected void destroyGraphObserver(final GraphObserver observer) {
+        if (this.observers.remove(observer)) {
+            ((GraphObserverImpl) observer).destroyObserver();
+        }
+    }
+
+    @Override
+    public Iterable<HierarchicalNodeGroup> getGroups() {
+        final List<HierarchicalNodeGroup> groups = new ArrayList<HierarchicalNodeGroup>();
+        groups.add(this.root);
+        for (final HierarchicalNodeGroupImpl group : this.root.getGroups(true)) {
+            groups.add(group);
+        }
+        return Collections.unmodifiableList(groups);
+    }
+
+    @Override
+    public HierarchicalNodeGroup getRoot() {
+        return this.root;
+    }
+
+    @Override
+    public HierarchicalNodeGroup getGroup(final Node node) {
+        if (null == node) {
+            return null;
+        }
+
+        return this.root.find(node, true);
+    }
+
+    protected Collection<Node> mapWithHidden(final Node node) {
+        if (null == node) {
+            return Collections.emptyList();
+        }
+
+        final HierarchicalNodeGroupImpl group = this.root.find(node, true);
+        if (null == group) {
+            return Collections.singleton(node);
+        }
+
+        if (group.hasCollapsedParent()) {
+            return Collections.emptyList();
+        }
+
+        if (group.isCollapsed()) {
+            final Collection<Node> children = group.getNodes(true);
+            final Set<Node> set = new HashSet<Node>(children.size() + 1);
+            set.add(node);
+            set.addAll(children);
+            return Collections.unmodifiableCollection(set);
+        }
+
+        return Collections.singleton(node);
+    }
+
+    protected Node mapToVisible(final Node node) {
+        final HierarchicalNodeGroupImpl group = this.root.find(node, true);
+        if (null == group) {
+            return node;
+        } else {
+            return group.mappedNode();
+        }
+    }
+
+    private class HierarchicalNodeGroupImpl implements HierarchicalNodeGroup {
+        private final HierarchicalNodeGroupImpl parent;
+
+        private final Node node;
+
+        private boolean collapsed = false;
+
+        private final Object2ObjectMap<Node, HierarchicalNodeGroupImpl> nodeMap = new Object2ObjectOpenHashMap<Node, HierarchicalNodeGroupImpl>();
+
+        private HierarchicalNodeGroupImpl(final HierarchicalNodeGroupImpl parent, final Node node) {
+            this.parent = parent;
+            this.node = node;
+        }
+
+        public void clear() {
+            if (!this.nodeMap.isEmpty()) {
+                return;
+            }
+
+            for (final HierarchicalNodeGroupImpl group : this.nodeMap.values()) {
+                group.clear();
+            }
+            this.nodeMap.clear();
+        }
+
+        @Override
+        public HierarchicalNodeGroup addNode(final Node childNode) {
+            if (null == childNode) {
+                return null;
+            }
+
+            if (this.node == childNode) {
+                throw new IllegalArgumentException("Child and parent node are the same.");
+            }
+
+            graphStore.autoWriteLock();
+            try {
+                if (this.nodeMap.containsKey(childNode)) {
+                    return null;
+                }
+
+                final HierarchicalNodeGroupImpl group = new HierarchicalNodeGroupImpl(this, childNode);
+                this.nodeMap.put(childNode, group);
+                return group;
+            } finally {
+                graphStore.autoWriteUnlock();
+            }
+        }
+
+        @Override
+        public boolean removeNode(final Node childNode) {
+            if (null == childNode) {
+                return false;
+            }
+
+            return this.removeNode(childNode, false);
+        }
+
+        public boolean removeNode(final Node childNode, final boolean recursive) {
+            if (null == childNode) {
+                return false;
+            }
+
+            graphStore.autoWriteLock();
+            try {
+                return this.removeNodeWithLock(childNode, recursive);
+            } finally {
+                graphStore.autoWriteUnlock();
+            }
+        }
+
+        private boolean removeNodeWithLock(final Node childNode, final boolean recursive) {
+            boolean updated = this.nodeMap.get(childNode) != null;
+            if (recursive) {
+                for (final HierarchicalNodeGroupImpl group : this.nodeMap.values()) {
+                    updated |= group.removeNodeWithLock(childNode, true);
+                }
+            }
+            return updated;
+        }
+
+        public HierarchicalNodeGroupImpl find(final Node childNode, final boolean recursive) {
+            graphStore.autoReadLock();
+            try {
+                return this.findWithLock(childNode, recursive);
+            } finally {
+                graphStore.autoReadUnlock();
+            }
+        }
+
+        private HierarchicalNodeGroupImpl findWithLock(final Node childNode, final boolean recursive) {
+            final HierarchicalNodeGroupImpl existing = this.nodeMap.get(childNode);
+            if (existing != null) {
+                return existing;
+            }
+
+            if (!recursive) {
+                return null;
+            }
+
+            for (final HierarchicalNodeGroupImpl child : nodeMap.values()) {
+                final HierarchicalNodeGroupImpl existingChild = child.findWithLock(childNode, true);
+                if (existingChild != null) {
+                    return existingChild;
+                }
+            }
+
+            return null;
+        }
+
+        public Node mappedNode() {
+            if (this.node != null) {
+                // child node
+                HierarchicalNodeGroupImpl childGroup = this;
+                HierarchicalNodeGroupImpl parentGroup = this.parent;
+                while (parentGroup != null) {
+                    if (null == parentGroup.node) {
+                        return childGroup.node;
+                    }
+                    if (parentGroup.isExpanded()) {
+                        return childGroup.node;
+                    }
+                    final HierarchicalNodeGroupImpl tmp = parentGroup;
+                    parentGroup = parentGroup.parent;
+                    childGroup = tmp;
+                }
+                return null;
+            } else {
+                // first tier node, always visible
+                return null;
+            }
+        }
+
+        public boolean hasCollapsedParent() {
+            graphStore.autoReadLock();
+            try {
+                HierarchicalNodeGroupImpl group = this.parent;
+                while (group != null) {
+                    if (group.isCollapsed()) {
+                        return true;
+                    }
+                    group = group.parent;
+                }
+                return false;
+            } finally {
+                graphStore.autoReadUnlock();
+            }
+        }
+
+        @Override
+        public boolean isCollapsed() {
+            graphStore.autoReadLock();
+            try {
+                return this.collapsed;
+            } finally {
+                graphStore.autoReadUnlock();
+            }
+        }
+
+        @Override
+        public boolean isExpanded() {
+            return !this.isCollapsed();
+        }
+
+        @Override
+        public void expand() {
+            this.collapsed = false;
+            for (final HierarchicalNodeGroupImpl child : this.nodeMap.values()) {
+                child.expand();
+            }
+        }
+
+        @Override
+        public void collapse() {
+            this.collapsed = true;
+            for (final HierarchicalNodeGroupImpl child : this.nodeMap.values()) {
+                child.collapse();
+            }
+        }
+
+        @Override
+        public Iterable<Node> getNodes() {
+            graphStore.autoReadLock();
+            final List<Node> list;
+            try {
+                list = new ArrayList<Node>(this.nodeMap.keySet());
+            } finally {
+                graphStore.autoReadUnlock();
+            }
+            return Collections.unmodifiableCollection(list);
+        }
+
+        @Override
+        public Collection<Node> getNodes(boolean recursive) {
+            graphStore.autoReadLock();
+            final Set<Node> set = new HashSet<Node>(this.nodeMap.size());
+            try {
+                if (recursive) {
+                    for (final Map.Entry<Node, HierarchicalNodeGroupImpl> entry : this.nodeMap.entrySet()) {
+                        set.add(entry.getKey());
+                        if (recursive) {
+                            set.addAll(entry.getValue().getNodes(true));
+                        }
+                    }
+                }
+            } finally {
+                graphStore.autoReadUnlock();
+            }
+            return Collections.unmodifiableCollection(set);
+        }
+
+        public Collection<HierarchicalNodeGroupImpl> getGroups(final boolean recursive) {
+            graphStore.autoReadLock();
+            final List<HierarchicalNodeGroupImpl> list;
+            try {
+                if (recursive) {
+                    list = new ArrayList<HierarchicalNodeGroupImpl>();
+                    for (final HierarchicalNodeGroupImpl group : this.nodeMap.values()) {
+                        list.add(group);
+                        list.addAll(group.getGroups(true));
+                    }
+                } else {
+                    list = new ArrayList<HierarchicalNodeGroupImpl>(this.nodeMap.values());
+                }
+            } finally {
+                graphStore.autoReadUnlock();
+            }
+            return Collections.unmodifiableCollection(list);
+        }
+    }
+}

--- a/store/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/store/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -586,7 +586,7 @@ public class Serialization {
     private void serializeGraphView(final DataOutput out, final GraphViewImpl view) throws IOException {
         serialize(out, view.nodeView);
         serialize(out, view.edgeView);
-        serialize(out, view.storeId);
+        serialize(out, view.getStoreId());
         serialize(out, view.nodeCount);
         serialize(out, view.edgeCount);
 
@@ -600,7 +600,7 @@ public class Serialization {
         serialize(out, view.version);
 
         serialize(out, view.attributes);
-        serialize(out, view.interval);
+        serialize(out, view.getTimeInterval());
     }
 
     private GraphViewImpl deserializeGraphView(final DataInput is) throws IOException, ClassNotFoundException {
@@ -624,7 +624,7 @@ public class Serialization {
         view.edgeCount = edgeCount;
         view.nodeBitVector = nodeCountVector;
         view.edgeBitVector = edgeCountVector;
-        view.storeId = storeId;
+        view.setStoreId(storeId);
 
         view.typeCounts = typeCounts;
         view.mutualEdgesCount = mutualEdgesCount;
@@ -634,7 +634,7 @@ public class Serialization {
         view.version.edgeVersion = version.edgeVersion;
 
         view.attributes.setGraphAttributes(atts);
-        view.interval = interval;
+        view.setTimeInterval(interval);
 
         return view;
     }

--- a/store/src/test/java/org/gephi/graph/impl/GraphViewStoreTest.java
+++ b/store/src/test/java/org/gephi/graph/impl/GraphViewStoreTest.java
@@ -67,7 +67,7 @@ public class GraphViewStoreTest {
 
         Assert.assertFalse(store.contains(view));
         Assert.assertEquals(store.size(), 0);
-        Assert.assertEquals(view.storeId, GraphViewStore.NULL_VIEW);
+        Assert.assertEquals(view.getStoreId(), GraphViewStore.NULL_VIEW);
         Assert.assertTrue(view.isDestroyed());
     }
 
@@ -128,7 +128,7 @@ public class GraphViewStoreTest {
 
         view = store.createView();
 
-        Assert.assertEquals(view.storeId, 0);
+        Assert.assertEquals(view.getStoreId(), 0);
         Assert.assertEquals(store.length, 1);
         Assert.assertEquals(store.garbageQueue.size(), 0);
     }

--- a/store/src/test/java/org/gephi/graph/impl/HierarchicalGraphTest.java
+++ b/store/src/test/java/org/gephi/graph/impl/HierarchicalGraphTest.java
@@ -1,0 +1,115 @@
+package org.gephi.graph.impl;
+
+import org.gephi.graph.api.DirectedSubgraph;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.HierarchicalGraphView;
+import org.gephi.graph.api.HierarchicalNodeGroup;
+import org.gephi.graph.api.Node;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class HierarchicalGraphTest {
+    @Test
+    public void testSimpleExpandCollapse() {
+        GraphStore graphStore = GraphGenerator.generateSmallMultiTypeGraphStore();
+        GraphViewStore store = graphStore.viewStore;
+        HierarchicalGraphView view = store.createHierarchicalView();
+        DirectedSubgraph graph = store.getDirectedGraph(view);
+
+        for (Node node : graphStore.getNodes().toArray()) {
+            graph.addNode(node);
+        }
+        for (Edge edge : graphStore.getEdges().toArray()) {
+            graph.addEdge(edge);
+        }
+
+        int originalCount = store.getGraph(view).getNodeCount();
+
+        Node parentNode = store.getGraph(view).getNode("7");
+        HierarchicalNodeGroup group = view.getRoot().addNode(parentNode);
+        Assert.assertEquals(originalCount, graph.getNodeCount());
+
+        Node childNode = store.getGraph(view).getNode("3");
+        group.addNode(childNode);
+        Assert.assertEquals(originalCount, graph.getNodeCount());
+
+        Assert.assertFalse(graph.getEdges(parentNode).toCollection().isEmpty());
+        Assert.assertFalse(graph.getEdges(childNode).toCollection().isEmpty());
+
+        int edgeCountForParent = graph.getDegree(parentNode);
+        int edgeCountForChild = graph.getDegree(childNode);
+
+        group.collapse();
+
+        Assert.assertEquals(originalCount - 1, graph.getNodeCount());
+        Assert.assertFalse(graph.hasNode("3"));
+        Assert.assertEquals(edgeCountForParent + edgeCountForChild, graph.getDegree(parentNode));
+        Assert.assertEquals(0, graph.getDegree(childNode));
+
+        Assert.assertFalse(graph.getEdges(parentNode).toCollection().isEmpty());
+        Assert.assertTrue(graph.getEdges(childNode).toCollection().isEmpty());
+
+        graph.clearEdges();
+
+        Assert.assertTrue(graph.getEdges(parentNode).toCollection().isEmpty());
+        Assert.assertTrue(graph.getEdges(childNode).toCollection().isEmpty());
+    }
+
+    @Test
+    public void testManipulateEdges() {
+        GraphStore graphStore = GraphGenerator.generateSmallMultiTypeGraphStore();
+        GraphViewStore store = graphStore.viewStore;
+        HierarchicalGraphView view = store.createHierarchicalView();
+        DirectedSubgraph graph = store.getDirectedGraph(view);
+
+        for (Node node : graphStore.getNodes().toArray()) {
+            graph.addNode(node);
+        }
+        for (Edge edge : graphStore.getEdges().toArray()) {
+            graph.addEdge(edge);
+        }
+
+        Node parentNode = store.getGraph(view).getNode("7");
+        HierarchicalNodeGroup group = view.getRoot().addNode(parentNode);
+        Node childNode = store.getGraph(view).getNode("3");
+        group.addNode(childNode);
+
+        Set<Node> others = new HashSet<Node>();
+        for (Edge edge : graph.getEdges(childNode)) {
+            Node other = graph.getOpposite(childNode, edge);
+            Assert.assertNotNull(other);
+            Assert.assertFalse(other.equals(childNode));
+            others.add(other);
+        }
+        Assert.assertFalse(others.isEmpty());
+
+        group.collapse();
+
+        Set<Edge> mapped = new HashSet<Edge>();
+        for (Node other : others) {
+            for (Edge edge : graph.getEdges(other)) {
+                if (edge instanceof HierarchicalGraphDecorator.MappedEdgeDecorator) {
+                    if (edge.getSource() != edge.getTarget()) {
+                        Assert.assertFalse(edge.getSource() == childNode || edge.getTarget() == childNode);
+                        Assert.assertTrue(edge.getSource() == parentNode || edge.getTarget() == parentNode);
+                        Assert.assertTrue(edge.getSource() == other || edge.getTarget() == other);
+                        mapped.add(edge);
+                    }
+                }
+            }
+        }
+        Assert.assertFalse(mapped.isEmpty());
+
+        for (Edge edge : mapped) {
+            Node other = graph.getOpposite(childNode, edge);
+            Assert.assertNull(other);
+            other = graph.getOpposite(parentNode, edge);
+            Assert.assertNotNull(other);
+            Assert.assertTrue(others.contains(other));
+            graph.removeEdge(edge);
+        }
+    }
+}


### PR DESCRIPTION
The hierarchical graph api was removed in Geph 0.9.x, but represented a valuable api not widely available in other open source graph libraries.  This implementation incorporates the hierarchical classes by abstracting the graph view, rather than core graph, and allows the UI to determine which nodes are collapsed/expanded (and therefore visible) for layouts and interaction.  The core graph api remains unchanged.