### PR TITLE
#162 Configuration refactoring

### DIFF
--- a/src/main/java/org/gephi/graph/api/Column.java
+++ b/src/main/java/org/gephi/graph/api/Column.java
@@ -152,6 +152,7 @@ public interface Column {
      *
      * @param withDiff true if column observer should provide column differences
      * @return the column observer
+     * @throws UnsupportedOperationException if observers are disabled (from Configuration)
      */
     public ColumnObserver createColumnObserver(boolean withDiff);
 }

--- a/src/main/java/org/gephi/graph/api/Column.java
+++ b/src/main/java/org/gephi/graph/api/Column.java
@@ -152,7 +152,8 @@ public interface Column {
      *
      * @param withDiff true if column observer should provide column differences
      * @return the column observer
-     * @throws UnsupportedOperationException if observers are disabled (from Configuration)
+     * @throws UnsupportedOperationException if observers are disabled (from
+     *         Configuration)
      */
     public ColumnObserver createColumnObserver(boolean withDiff);
 }

--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -80,6 +80,11 @@ public class Configuration {
          * @return the configuration
          */
         public Configuration build() {
+            // Check for potential inconsistencies
+            if (!configuration.isEnableNodeProperties() && configuration.isEnableSpatialIndex()) {
+                throw new IllegalStateException("Spatial index can't be enabled if node properties are disabled");
+            }
+
             return new Configuration(configuration);
         }
 

--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -358,6 +358,25 @@ public class Configuration {
             return this;
         }
 
+        /**
+         * Sets whether to enable multiple edges of the same type between two nodes.
+         * <p>
+         * If disabled, only a single edge of a given type can exist between two nodes.
+         * <p>
+         * Default is <code>false</code>.
+         * @param enableParallelEdgesSameType enable parallel edges of the same type
+         * @return this builder
+         */
+        public Builder enableParallelEdgesSameType(final boolean enableParallelEdgesSameType) {
+            this.configuration = new ConfigurationImpl(new Configuration(this.configuration) {
+                @Override
+                public boolean isEnableParallelEdgesSameType() {
+                    return enableParallelEdgesSameType;
+                }
+            });
+            return this;
+        }
+
         private static void checkSimpleType(Class type) {
             if (!AttributeUtils.isSimpleType(type)) {
                 throw new IllegalArgumentException("Unsupported type " + type.getCanonicalName());
@@ -533,6 +552,10 @@ public class Configuration {
 
     public boolean isEnableSpatialIndex() {
         return delegate.isEnableSpatialIndex();
+    }
+
+    public boolean isEnableParallelEdgesSameType() {
+        return delegate.isEnableParallelEdgesSameType();
     }
 
     /**

--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -26,13 +26,21 @@ import org.gephi.graph.impl.ConfigurationImpl;
  * {@link GraphModel.Factory#newInstance(org.gephi.graph.api.Configuration)} to
  * create a <em>GraphModel</em> with custom configuration.
  * <p>
+ * Create instances by using the builder:
+ * <pre>
+ * Configuration config = Configuration.builder().build();
+ * </pre>
+ * <p>
  * Note that setting configurations after the <em>GraphModel</em> has been
  * created won't have any effect.
  * <p>
  * By default, both node and edge id types are <code>String.class</code> and the
  * time representation is <code>TIMESTAMP</code>.
+ * <p>
+ * See the builder documentation for more information on default values.
  *
  * @see GraphModel
+ * @see Builder
  */
 public class Configuration {
 

--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -105,7 +105,6 @@ public class Configuration {
             return this;
         }
 
-
         /**
          * Sets the edge id type.
          * <p>
@@ -153,7 +152,8 @@ public class Configuration {
         /**
          * Sets the edge weight type.
          * <p>
-         * <code>Double</code>, <code>IntervalDoubleMap</code> and <code>TimestampDoubleMap</code> are supported.
+         * <code>Double</code>, <code>IntervalDoubleMap</code> and
+         * <code>TimestampDoubleMap</code> are supported.
          * <p>
          * Default is <code>Double.class</code>.
          *
@@ -163,8 +163,9 @@ public class Configuration {
          */
         public Builder edgeWeightType(final Class edgeWeightType) {
             if (!(Double.class.equals(edgeWeightType) || TimestampDoubleMap.class
-                .equals(edgeWeightType) || IntervalDoubleMap.class.equals(edgeWeightType))) {
-                throw new IllegalArgumentException("Unsupported type " + edgeWeightType.getCanonicalName() + ", should be Double, IntervalDoubleMap or TimestampDoubleMap");
+                    .equals(edgeWeightType) || IntervalDoubleMap.class.equals(edgeWeightType))) {
+                throw new IllegalArgumentException("Unsupported type " + edgeWeightType
+                        .getCanonicalName() + ", should be Double, IntervalDoubleMap or TimestampDoubleMap");
             }
             this.configuration = new ConfigurationImpl(new Configuration(this.configuration) {
                 @Override
@@ -235,10 +236,12 @@ public class Configuration {
         /**
          * Sets whether to enable auto edge type registration.
          * <p>
-         * If enabled, edge types are automatically registered when edges are added. If disabled, one needs to call
-         * {@link GraphModel#addEdgeType(Object)} explicitly for each type.
+         * If enabled, edge types are automatically registered when edges are added. If
+         * disabled, one needs to call {@link GraphModel#addEdgeType(Object)} explicitly
+         * for each type.
          * <p>
          * Default is <code>true</code>.
+         * 
          * @param enableAutoEdgeTypeRegistration enable auto edge type registration
          * @return this builder
          */
@@ -255,10 +258,11 @@ public class Configuration {
         /**
          * Sets whether to enable node properties.
          * <p>
-         * If enabled, {@link NodeProperties} are created for each node. If those properties aren't needed, disabling them
-         * can save memory.
+         * If enabled, {@link NodeProperties} are created for each node. If those
+         * properties aren't needed, disabling them can save memory.
          * <p>
          * Default is <code>true</code>.
+         * 
          * @param enableNodeProperties enable node properties
          * @return this builder
          */
@@ -275,10 +279,11 @@ public class Configuration {
         /**
          * Sets whether to enable edge properties.
          * <p>
-         * If enabled, {@link EdgeProperties} are created for each edge. If those properties aren't needed, disabling them
-         * can save memory.
+         * If enabled, {@link EdgeProperties} are created for each edge. If those
+         * properties aren't needed, disabling them can save memory.
          * <p>
          * Default is <code>true</code>.
+         * 
          * @param enableEdgeProperties enable edge properties
          * @return this builder
          */
@@ -295,12 +300,13 @@ public class Configuration {
         /**
          * Sets whether to enable the {@link SpatialIndex}.
          * <p>
-         * If enabled, the spatial index is updated while node positions are updated. If unused, disabling it is
-         * recommended as it adds some overhead.
+         * If enabled, the spatial index is updated while node positions are updated. If
+         * unused, disabling it is recommended as it adds some overhead.
          * <p>
          * The spatial index can be retrieved from {@link GraphModel#getSpatialIndex()}.
          * <p>
          * Default is <code>false</code>.
+         * 
          * @param enableSpatialIndex enable edge properties
          * @return this builder
          */
@@ -318,11 +324,13 @@ public class Configuration {
          * Sets whether to enable the reverse indexing of node attributes.
          * <p>
          * If enabled, the reverse index is updated while node attributes are updated.
-         * This powers {@link GraphModel#getNodeIndex()} but has a negative impact on memory usage (as any reverse index does).
-         * When disabled, the features of {@link Index<Node>} are still available but need to iterate over all nodes
-         * to return results.
+         * This powers {@link GraphModel#getNodeIndex()} but has a negative impact on
+         * memory usage (as any reverse index does). When disabled, the features of
+         * {@link Index<Node>} are still available but need to iterate over all nodes to
+         * return results.
          * <p>
          * Default is <code>true</code>.
+         * 
          * @param enableIndexNodes enable node attribute indexing
          * @return this builder
          */
@@ -340,11 +348,13 @@ public class Configuration {
          * Sets whether to enable the reverse indexing of edge attributes.
          * <p>
          * If enabled, the reverse index is updated while node attributes are updated.
-         * This powers {@link GraphModel#getEdgeIndex()} but has a negative impact on memory usage (as any reverse index does).
-         * When disabled, the features of {@link Index<Edge>} are still available but need to iterate over all nodes
-         * to return results.
+         * This powers {@link GraphModel#getEdgeIndex()} but has a negative impact on
+         * memory usage (as any reverse index does). When disabled, the features of
+         * {@link Index<Edge>} are still available but need to iterate over all nodes to
+         * return results.
          * <p>
          * Default is <code>true</code>.
+         * 
          * @param enableIndexEdges enable edge attribute indexing
          * @return this builder
          */
@@ -364,6 +374,7 @@ public class Configuration {
          * If disabled, only a single edge of a given type can exist between two nodes.
          * <p>
          * Default is <code>false</code>.
+         * 
          * @param enableParallelEdgesSameType enable parallel edges of the same type
          * @return this builder
          */
@@ -509,6 +520,7 @@ public class Configuration {
     /**
      * Sets whether to create an edge weight column.
      * <p>
+     * 
      * @deprecated Use {@link #builder()} instead.
      *
      * @param edgeWeightColumn edge weight column

--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -18,7 +18,6 @@ package org.gephi.graph.api;
 import org.gephi.graph.api.types.IntervalDoubleMap;
 import org.gephi.graph.api.types.TimestampDoubleMap;
 import org.gephi.graph.impl.ConfigurationImpl;
-import org.gephi.graph.impl.GraphStoreConfiguration;
 
 /**
  * Global configuration set at initialization.
@@ -62,6 +61,12 @@ public class Configuration {
         return new Builder();
     }
 
+    /**
+     * Configuration builder.
+     * <p>
+     *
+     * Note that this class is not thread-safe.
+     */
     public static class Builder {
 
         private ConfigurationImpl configuration;
@@ -374,6 +379,29 @@ public class Configuration {
         }
 
         /**
+         * Sets whether to enable the reverse indexing of timestamps and intervals.
+         * <p>
+         * If enabled, the reverse index is updated while element's time set is updated.
+         * This powers {@link GraphModel#getNodeTimeIndex()} and
+         * {@link GraphModel#getEdgeTimeIndex()} ()} but has a negative impact on memory
+         * usage (as any reverse index does).
+         * <p>
+         * Default is <code>true</code>.
+         *
+         * @param enableIndexTime enable time indexing
+         * @return this builder
+         */
+        public Builder enableIndexTime(final boolean enableIndexTime) {
+            this.configuration = new ConfigurationImpl(new Configuration(this.configuration) {
+                @Override
+                public boolean isEnableIndexTime() {
+                    return enableIndexTime;
+                }
+            });
+            return this;
+        }
+
+        /**
          * Sets whether to enable multiple edges of the same type between two nodes.
          * <p>
          * If disabled, only a single edge of a given type can exist between two nodes.
@@ -388,6 +416,30 @@ public class Configuration {
                 @Override
                 public boolean isEnableParallelEdgesSameType() {
                     return enableParallelEdgesSameType;
+                }
+            });
+            return this;
+        }
+
+        /**
+         * Sets whether to enable auto locking when using read/write APIs.
+         * <p>
+         * If disabled, the client is responsible for handling multithreading themselves
+         * or calling methods such as {@link Graph#readLock()} or
+         * {@link Graph#writeLock()}. If enabled, each read methods (including
+         * iterators) handle locking. Similarly, each write method handle locking.
+         * <p>
+         * Default is <code>true</code>.
+         *
+         * @param enableAutoLocking enable auto locking for read/write operations
+         * @see GraphLock
+         * @return this builder
+         */
+        public Builder enableAutoLocking(final boolean enableAutoLocking) {
+            this.configuration = new ConfigurationImpl(new Configuration(this.configuration) {
+                @Override
+                public boolean isEnableAutoLocking() {
+                    return enableAutoLocking;
                 }
             });
             return this;
@@ -551,8 +603,8 @@ public class Configuration {
         return delegate.isEnableIndexEdges();
     }
 
-    public boolean isEnableIndexTimestamps() {
-        return delegate.isEnableIndexTimestamps();
+    public boolean isEnableIndexTime() {
+        return delegate.isEnableIndexTime();
     }
 
     public boolean isEnableObservers() {

--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -45,7 +45,10 @@ public class Configuration {
 
     /**
      * Default constructor.
+     *
+     * @deprecated Use the <code>builder()</code> method instead.
      */
+    @Deprecated
     public Configuration() {
         nodeIdType = GraphStoreConfiguration.DEFAULT_NODE_ID_TYPE;
         edgeIdType = GraphStoreConfiguration.DEFAULT_EDGE_ID_TYPE;
@@ -53,6 +56,117 @@ public class Configuration {
         edgeWeightType = GraphStoreConfiguration.DEFAULT_EDGE_WEIGHT_TYPE;
         timeRepresentation = GraphStoreConfiguration.DEFAULT_TIME_REPRESENTATION;
         edgeWeightColumn = true;
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private final Configuration configuration;
+
+        private Builder() {
+            configuration = new Configuration();
+        }
+
+        /**
+         * Builds the configuration.
+         *
+         * @return the configuration
+         */
+        public Configuration build() {
+            return configuration;
+        }
+
+        /**
+         * Sets the node id type.
+         * <p>
+         * Only simple types such as primitives, wrappers and String are supported.
+         * <p>
+         * Default is <code>String.class</code>.
+         *
+         * @param nodeIdType node id type
+         * @throws IllegalArgumentException if the type isn't supported
+         */
+        public Builder nodeIdType(Class nodeIdType) {
+            configuration.setNodeIdType(nodeIdType);
+            return this;
+        }
+
+
+        /**
+         * Sets the edge id type.
+         * <p>
+         * Only simple types such as primitives, wrappers and String are supported.
+         * <p>
+         * Default is <code>String.class</code>.
+         *
+         * @param edgeIdType edge id type
+         * @throws IllegalArgumentException if the type isn't supported
+         */
+        public Builder edgeIdType(Class edgeIdType) {
+            configuration.setEdgeIdType(edgeIdType);
+            return this;
+        }
+
+        /**
+         * Sets the edge label type.
+         * <p>
+         * Only simple types such as primitives, wrappers and String are supported.
+         * <p>
+         * Default is <code>String.class</code>.
+         *
+         * @param edgeLabelType edge label type
+         * @throws IllegalArgumentException if the type isn't supported
+         */
+        public Builder setEdgeLabelType(Class edgeLabelType) {
+            configuration.setEdgeLabelType(edgeLabelType);
+            return this;
+        }
+
+        /**
+         * Sets the edge weight type.
+         * <p>
+         * <code>Double</code>, <code>IntervalDoubleMap</code> and <code>TimestampDoubleMap</code> are supported.
+         * <p>
+         * Default is <code>Double.class</code>.
+         *
+         * @param edgeWeightType edge weight type
+         * @throws IllegalArgumentException if the type isn't supported
+         */
+        public Builder edgeWeightType(Class edgeWeightType) {
+            configuration.setEdgeWeightType(edgeWeightType);
+            return this;
+        }
+
+        /**
+         * Sets the time representation.
+         * <p>
+         * Default is <code>TIMESTAMP</code>.
+         *
+         * @param timeRepresentation time representation
+         */
+        public Builder timeRepresentation(TimeRepresentation timeRepresentation) {
+            configuration.setTimeRepresentation(timeRepresentation);
+            return this;
+        }
+
+        /**
+         * Sets whether to create an edge weight column.
+         * <p>
+         * Default is <code>true</code>.
+         *
+         * @param edgeWeightColumn edge weight column
+         */
+        public void edgeWeightColumn(Boolean edgeWeightColumn) {
+            configuration.setEdgeWeightColumn(edgeWeightColumn);
+        }
     }
 
     /**
@@ -69,9 +183,12 @@ public class Configuration {
      * <p>
      * Only simple types such as primitives, wrappers and String are supported.
      *
+     * @deprecated Use {@link #builder()} instead.
+     *
      * @param nodeIdType node id type
      * @throws IllegalArgumentException if the type isn't supported
      */
+    @Deprecated
     public void setNodeIdType(Class nodeIdType) {
         if (!AttributeUtils.isSimpleType(nodeIdType)) {
             throw new IllegalArgumentException("Unsupported type " + nodeIdType.getClass().getCanonicalName());
@@ -93,9 +210,12 @@ public class Configuration {
      * <p>
      * Only simple types such as primitives, wrappers and String are supported.
      *
+     * @deprecated Use {@link #builder()} instead.
+     *
      * @param edgeIdType edge id type
      * @throws IllegalArgumentException if the type isn't supported
      */
+    @Deprecated
     public void setEdgeIdType(Class edgeIdType) {
         if (!AttributeUtils.isSimpleType(edgeIdType)) {
             throw new IllegalArgumentException("Unsupported type " + edgeIdType.getClass().getCanonicalName());
@@ -115,9 +235,12 @@ public class Configuration {
     /**
      * Sets the edge label type.
      *
+     * @deprecated Use {@link #builder()} instead.
+     *
      * @param edgeLabelType edge label type
      * @throws IllegalArgumentException if the type isn't supported
      */
+    @Deprecated
     public void setEdgeLabelType(Class edgeLabelType) {
         if (!AttributeUtils.isSimpleType(edgeLabelType)) {
             throw new IllegalArgumentException("Unsupported type " + edgeLabelType.getClass().getCanonicalName());
@@ -137,9 +260,12 @@ public class Configuration {
     /**
      * Sets the edge weight type.
      *
+     * @deprecated Use {@link #builder()} instead.
+     *
      * @param edgeWeightType edge weight type
      * @throws IllegalArgumentException if the type isn't supported
      */
+    @Deprecated
     public void setEdgeWeightType(Class edgeWeightType) {
         if (Double.class.equals(edgeWeightType) || TimestampDoubleMap.class
                 .equals(edgeWeightType) || IntervalDoubleMap.class.equals(edgeWeightType)) {
@@ -161,8 +287,11 @@ public class Configuration {
     /**
      * Sets the time representation.
      *
+     * @deprecated Use {@link #builder()} instead.
+     *
      * @param timeRepresentation time representation
      */
+    @Deprecated
     public void setTimeRepresentation(TimeRepresentation timeRepresentation) {
         if (timeRepresentation == null) {
             throw new IllegalArgumentException("timeRepresentation cannot be null");
@@ -181,9 +310,12 @@ public class Configuration {
 
     /**
      * Sets whether to create an edge weight column.
+     * <p>
+     * @deprecated Use {@link #builder()} instead.
      *
      * @param edgeWeightColumn edge weight column
      */
+    @Deprecated
     public void setEdgeWeightColumn(Boolean edgeWeightColumn) {
         this.edgeWeightColumn = edgeWeightColumn;
     }

--- a/src/main/java/org/gephi/graph/api/GraphModel.java
+++ b/src/main/java/org/gephi/graph/api/GraphModel.java
@@ -139,7 +139,8 @@ public interface GraphModel {
 
         /**
          * Read the <code>input</code> into the given graph model. The provided graph
-         * model should be empty.
+         * model should be empty and the configurations should match between the provided model and
+         * the one being read.
          *
          * @param input data input to read from
          * @return the graphmodel passed as parameter

--- a/src/main/java/org/gephi/graph/api/GraphModel.java
+++ b/src/main/java/org/gephi/graph/api/GraphModel.java
@@ -42,10 +42,17 @@ import org.gephi.graph.impl.GraphModelImpl;
  * <pre>
  * GraphModel model = GraphModel.Factory.newInstance();
  * </pre>
+ *
+ * A <code>Configuration</code> object can be passed to the factory:
+ *
+ * <pre>
+ * Configuration configuration = Configuration.builder().build();
+ * GraphModel model = GraphModel.Factory.newInstance(configuration);
+ * </pre>
  * 
  * This API revolves around a set of simple concepts. A <code>GraphModel</code>
  * encapsulate all elements and metadata associated with a graph structure. In
- * other words its a single graph but it also contains configuration, indices,
+ * other words it's a single graph, but it also contains configuration, indices,
  * views and other less important services such as observers.
  * <p>
  * Then, <code>GraphModel</code> gives access to the <code>Graph</code>
@@ -83,6 +90,7 @@ import org.gephi.graph.impl.GraphModelImpl;
  * <code>null</code> label, which is internally represented as zero.
  *
  * @see Graph
+ * @see Configuration
  * @see Element
  * @see Table
  * @see Column

--- a/src/main/java/org/gephi/graph/api/GraphModel.java
+++ b/src/main/java/org/gephi/graph/api/GraphModel.java
@@ -718,12 +718,14 @@ public interface GraphModel {
 
     /**
      * Sets a new configuration for this graph model.
-     * <p>
-     * Note that this method only works if the graph model is empty.
+     *
+     * @deprecated setting configuration after graph model creation is no longer supported. Best is to use the
+     * {@link Configuration#builder()} to create a new configuration and then use it at graph model creation from
+     * {@link GraphModel.Factory#newInstance(Configuration)}.
      *
      * @param configuration new configuration
-     * @throws IllegalStateException if the graph model isn't empty
      */
+    @Deprecated
     public void setConfiguration(Configuration configuration);
 
     /**

--- a/src/main/java/org/gephi/graph/api/GraphModel.java
+++ b/src/main/java/org/gephi/graph/api/GraphModel.java
@@ -139,8 +139,8 @@ public interface GraphModel {
 
         /**
          * Read the <code>input</code> into the given graph model. The provided graph
-         * model should be empty and the configurations should match between the provided model and
-         * the one being read.
+         * model should be empty and the configurations should match between the
+         * provided model and the one being read.
          *
          * @param input data input to read from
          * @return the graphmodel passed as parameter
@@ -720,9 +720,11 @@ public interface GraphModel {
     /**
      * Sets a new configuration for this graph model.
      *
-     * @deprecated setting configuration after graph model creation is no longer supported. Best is to use the
-     * {@link Configuration#builder()} to create a new configuration and then use it at graph model creation from
-     * {@link GraphModel.Factory#newInstance(Configuration)}.
+     * @deprecated setting configuration after graph model creation is no longer
+     *             supported. Best is to use the {@link Configuration#builder()} to
+     *             create a new configuration and then use it at graph model
+     *             creation from
+     *             {@link GraphModel.Factory#newInstance(Configuration)}.
      *
      * @param configuration new configuration
      */

--- a/src/main/java/org/gephi/graph/impl/ColumnImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnImpl.java
@@ -67,7 +67,7 @@ public class ColumnImpl implements Column {
         this.indexed = indexed;
         this.readOnly = readOnly;
         this.dynamic = TimeMap.class.isAssignableFrom(typeClass) || TimeSet.class.isAssignableFrom(typeClass);
-        this.observers = GraphStoreConfiguration.ENABLE_OBSERVERS ? new ArrayList<>() : null;
+        this.observers = table != null && table.store.graphStore.configuration.isEnableObservers() ? new ArrayList<>() : null;
         this.estimator = this.dynamic ? Estimator.FIRST : null;
     }
 
@@ -194,14 +194,14 @@ public class ColumnImpl implements Column {
             synchronized (observers) {
                 observers.add(observer);
             }
-
             return observer;
+        } else {
+            throw new UnsupportedOperationException("Observers are disabled. Enable them in Configuration");
         }
-        return null;
     }
 
     protected void destroyColumnObserver(ColumnObserverImpl observer) {
-        if (observers != null) {
+        if (observers != null && !observers.isEmpty()) {
             synchronized (observers) {
                 observers.remove(observer);
             }

--- a/src/main/java/org/gephi/graph/impl/ColumnImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnImpl.java
@@ -67,7 +67,7 @@ public class ColumnImpl implements Column {
         this.indexed = indexed;
         this.readOnly = readOnly;
         this.dynamic = TimeMap.class.isAssignableFrom(typeClass) || TimeSet.class.isAssignableFrom(typeClass);
-        this.observers = table != null && table.store.graphStore.configuration.isEnableObservers() ? new ArrayList<>() : null;
+        this.observers = table != null && table.configuration.isEnableObservers() ? new ArrayList<>() : null;
         this.estimator = this.dynamic ? Estimator.FIRST : null;
     }
 

--- a/src/main/java/org/gephi/graph/impl/ColumnNoIndexImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnNoIndexImpl.java
@@ -47,7 +47,7 @@ public class ColumnNoIndexImpl<K, T extends Element> implements ColumnIndexImpl<
         this.column = column;
         this.elementClass = elementClass;
         this.graph = graph;
-        this.graphLock = graph.getLock();
+        this.graphLock = graph != null ? graph.getLock() : null;
     }
 
     private Iterator<T> getElementIterator() {

--- a/src/main/java/org/gephi/graph/impl/ColumnStandardIndexImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnStandardIndexImpl.java
@@ -61,7 +61,7 @@ public abstract class ColumnStandardIndexImpl<K, T extends Element> implements C
     protected ColumnStandardIndexImpl(ColumnImpl column) {
         this.column = column;
         this.nullSet = new ValueSet<>(null);
-        this.lock = GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? new TableLockImpl() : null;
+        this.lock = column.table.store.graphStore.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
     }
 
     protected static boolean isSupportedType(ColumnImpl col) {

--- a/src/main/java/org/gephi/graph/impl/ColumnStandardIndexImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnStandardIndexImpl.java
@@ -61,7 +61,7 @@ public abstract class ColumnStandardIndexImpl<K, T extends Element> implements C
     protected ColumnStandardIndexImpl(ColumnImpl column) {
         this.column = column;
         this.nullSet = new ValueSet<>(null);
-        this.lock = column.table.store.graphStore.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
+        this.lock = column.table != null && column.table.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
     }
 
     protected static boolean isSupportedType(ColumnImpl col) {

--- a/src/main/java/org/gephi/graph/impl/ColumnStandardIndexImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnStandardIndexImpl.java
@@ -61,7 +61,8 @@ public abstract class ColumnStandardIndexImpl<K, T extends Element> implements C
     protected ColumnStandardIndexImpl(ColumnImpl column) {
         this.column = column;
         this.nullSet = new ValueSet<>(null);
-        this.lock = column.table != null && column.table.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
+        this.lock = column.table != null && column.table.configuration.isEnableAutoLocking() ? new TableLockImpl()
+                : null;
     }
 
     protected static boolean isSupportedType(ColumnImpl col) {

--- a/src/main/java/org/gephi/graph/impl/ColumnStore.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnStore.java
@@ -42,6 +42,8 @@ public class ColumnStore<T extends Element> implements ColumnIterable {
     protected final static int NULL_ID = -1;
     protected final static short NULL_SHORT = Short.MIN_VALUE;
     // Configuration
+    protected final ConfigurationImpl configuration;
+    // GraphStore
     protected final GraphStore graphStore;
     // Element
     protected final Class<T> elementType;
@@ -67,7 +69,13 @@ public class ColumnStore<T extends Element> implements ColumnIterable {
             throw new RuntimeException("Column Store size can't exceed 65534");
         }
         this.graphStore = graphStore;
-        this.lock = graphStore != null && graphStore.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
+        if (graphStore == null) {
+            // Used for testing only
+            configuration = new ConfigurationImpl();
+        } else {
+            configuration = graphStore.configuration;
+        }
+        this.lock = configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
         this.garbageQueue = new ShortRBTreeSet();
         this.idMap = new Object2ShortOpenHashMap<>(MAX_SIZE);
         this.columns = new ColumnImpl[MAX_SIZE];

--- a/src/main/java/org/gephi/graph/impl/ColumnStore.java
+++ b/src/main/java/org/gephi/graph/impl/ColumnStore.java
@@ -43,7 +43,6 @@ public class ColumnStore<T extends Element> implements ColumnIterable {
     protected final static short NULL_SHORT = Short.MIN_VALUE;
     // Configuration
     protected final GraphStore graphStore;
-    protected final Configuration configuration;
     // Element
     protected final Class<T> elementType;
     // Columns
@@ -60,44 +59,22 @@ public class ColumnStore<T extends Element> implements ColumnIterable {
     protected int length;
 
     public ColumnStore(Class<T> elementType, boolean indexed) {
-        this(null, elementType, indexed);
+        this(null, elementType);
     }
 
-    public ColumnStore(GraphStore graphStore, Class<T> elementType, boolean indexed) {
+    public ColumnStore(GraphStore graphStore, Class<T> elementType) {
         if (MAX_SIZE >= Short.MAX_VALUE - Short.MIN_VALUE + 1) {
             throw new RuntimeException("Column Store size can't exceed 65534");
         }
         this.graphStore = graphStore;
-        this.configuration = graphStore != null ? graphStore.configuration : new Configuration();
-        this.lock = GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? new TableLockImpl() : null;
+        this.lock = graphStore != null && graphStore.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
         this.garbageQueue = new ShortRBTreeSet();
         this.idMap = new Object2ShortOpenHashMap<>(MAX_SIZE);
         this.columns = new ColumnImpl[MAX_SIZE];
         this.elementType = elementType;
-        this.indexStore = indexed ? new IndexStore<>(this) : null;
+        this.indexStore = new IndexStore<>(this);
         idMap.defaultReturnValue(NULL_SHORT);
-        this.observers = GraphStoreConfiguration.ENABLE_OBSERVERS ? new ArrayList<>() : null;
-    }
-
-    private void updateConfiguration(Column changedColumn) {
-        String columnId = changedColumn.getId();
-        if (Edge.class.equals(elementType)) {
-            if (columnId.equals(GraphStoreConfiguration.EDGE_WEIGHT_COLUMN_ID)) {
-                if (hasColumn(columnId)) {
-                    Class edgeWeightColumnClass = getColumn(columnId).getTypeClass();
-                    configuration.setEdgeWeightType(edgeWeightColumnClass);
-                    configuration.setEdgeWeightColumn(true);
-                } else {
-                    configuration.setEdgeWeightColumn(false);
-                }
-            } else if (columnId.equals(GraphStoreConfiguration.ELEMENT_ID_COLUMN_ID)) {
-                configuration.setEdgeIdType(changedColumn.getTypeClass());
-            }
-        } else if (Node.class.equals(elementType)) {
-            if (columnId.equals(GraphStoreConfiguration.ELEMENT_ID_COLUMN_ID)) {
-                configuration.setNodeIdType(changedColumn.getTypeClass());
-            }
-        }
+        this.observers = new ArrayList<>();
     }
 
     public void addColumn(final Column column) {
@@ -126,8 +103,6 @@ public class ColumnStore<T extends Element> implements ColumnIterable {
                 if (indexStore != null) {
                     indexStore.addColumn(columnImpl);
                 }
-
-                updateConfiguration(column);
 
                 // Index attributes
                 if (graphStore != null && columnImpl.table != null) {
@@ -169,7 +144,6 @@ public class ColumnStore<T extends Element> implements ColumnIterable {
                 indexStore.removeColumn((ColumnImpl) column);
             }
             columnImpl.setStoreId(NULL_ID);
-            updateConfiguration(column);
         } finally {
             unlock();
         }

--- a/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
@@ -1,0 +1,220 @@
+package org.gephi.graph.impl;
+
+import org.gephi.graph.api.Configuration;
+import org.gephi.graph.api.TimeRepresentation;
+
+public class ConfigurationImpl {
+
+    // Node Id Type (default String)
+    private final Class nodeIdType;
+    // Edge Id Type (default String)
+    private final Class edgeIdType;
+    // Edge Label Type (default String)
+    private final Class edgeLabelType;
+    // Edge Weight Type (default Double)
+    private final Class edgeWeightType;
+    // Time representation (default Timestamp)
+    private final TimeRepresentation timeRepresentation;
+    // Use edge weight column, or just double (default True)
+    private final boolean edgeWeightColumn;
+    // Automatically use read/write locks when iterating/writing graph elements (default True)
+    private final boolean enableAutoLocking;
+    // Automatically register edge types when adding elements (default True)
+    private final boolean enableAutoEdgeTypeRegistration;
+    // Enable reverse index for node attributes (default True)
+    private final boolean enableIndexNodes;
+    // Enable reverse index for edge attributes (default True)
+    private final boolean enableIndexEdges;
+    private final boolean enableIndexTimestamps;
+    private final boolean enableObservers;
+    // Node properties are X, Y, Color etc. (default True)
+    private final boolean enableNodeProperties;
+    // Edge properties are Color, etc. (default True)
+    private final boolean enableEdgeProperties;
+    // Enable spatial index (default False)
+    private final boolean enableSpatialIndex;
+
+    public ConfigurationImpl() {
+        nodeIdType = GraphStoreConfiguration.DEFAULT_NODE_ID_TYPE;
+        edgeIdType = GraphStoreConfiguration.DEFAULT_EDGE_ID_TYPE;
+        edgeLabelType = GraphStoreConfiguration.DEFAULT_EDGE_LABEL_TYPE;
+        edgeWeightType = GraphStoreConfiguration.DEFAULT_EDGE_WEIGHT_TYPE;
+        timeRepresentation = GraphStoreConfiguration.DEFAULT_TIME_REPRESENTATION;
+        edgeWeightColumn = GraphStoreConfiguration.DEFAULT_ENABLE_EDGE_WEIGHT_COLUMN;
+        enableAutoLocking = GraphStoreConfiguration.DEFAULT_ENABLE_AUTO_LOCKING;
+        enableAutoEdgeTypeRegistration = GraphStoreConfiguration.DEFAULT_ENABLE_AUTO_EDGE_TYPE_REGISTRATION;
+        enableIndexNodes = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_NODES;
+        enableIndexEdges = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_EDGES;
+        enableIndexTimestamps = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_TIMESTAMP;
+        enableObservers = GraphStoreConfiguration.DEFAULT_ENABLE_OBSERVERS;
+        enableNodeProperties = GraphStoreConfiguration.DEFAULT_ENABLE_NODE_PROPERTIES;
+        enableEdgeProperties = GraphStoreConfiguration.DEFAULT_ENABLE_EDGE_PROPERTIES;
+        enableSpatialIndex = GraphStoreConfiguration.DEFAULT_ENABLE_SPATIAL_INDEX;
+    }
+
+    public ConfigurationImpl(Configuration configuration) {
+        nodeIdType = configuration.getNodeIdType();
+        edgeIdType = configuration.getEdgeIdType();
+        edgeLabelType = configuration.getEdgeLabelType();
+        edgeWeightType = configuration.getEdgeWeightType();
+        timeRepresentation = configuration.getTimeRepresentation();
+        edgeWeightColumn = configuration.getEdgeWeightColumn();
+        enableAutoLocking = configuration.isEnableAutoLocking();
+        enableAutoEdgeTypeRegistration = configuration.isEnableAutoEdgeTypeRegistration();
+        enableIndexNodes = configuration.isEnableIndexNodes();
+        enableIndexEdges = configuration.isEnableIndexEdges();
+        enableIndexTimestamps = configuration.isEnableIndexTimestamps();
+        enableObservers = configuration.isEnableObservers();
+        enableNodeProperties = configuration.isEnableNodeProperties();
+        enableEdgeProperties = configuration.isEnableEdgeProperties();
+        enableSpatialIndex = configuration.isEnableSpatialIndex();
+    }
+
+    public Configuration toConfiguration() {
+        return new ConfigurationProxy(this);
+    }
+
+    public Class getNodeIdType() {
+        return nodeIdType;
+    }
+
+    public Class getEdgeIdType() {
+        return edgeIdType;
+    }
+
+    public Class getEdgeLabelType() {
+        return edgeLabelType;
+    }
+
+    public Class getEdgeWeightType() {
+        return edgeWeightType;
+    }
+
+    public TimeRepresentation getTimeRepresentation() {
+        return timeRepresentation;
+    }
+
+    public boolean isEdgeWeightColumn() {
+        return edgeWeightColumn;
+    }
+
+    public boolean isEnableAutoLocking() {
+        return enableAutoLocking;
+    }
+
+    public boolean isEnableAutoEdgeTypeRegistration() {
+        return enableAutoEdgeTypeRegistration;
+    }
+
+    public boolean isEnableIndexNodes() {
+        return enableIndexNodes;
+    }
+
+    public boolean isEnableIndexEdges() {
+        return enableIndexEdges;
+    }
+
+    public boolean isEnableIndexTimestamps() {
+        return enableIndexTimestamps;
+    }
+
+    public boolean isEnableObservers() {
+        return enableObservers;
+    }
+
+    public boolean isEnableNodeProperties() {
+        return enableNodeProperties;
+    }
+
+    public boolean isEnableEdgeProperties() {
+        return enableEdgeProperties;
+    }
+
+    public boolean isEnableSpatialIndex() {
+        return enableSpatialIndex;
+    }
+
+    // Used to return a Configuration instance
+    private static class ConfigurationProxy extends Configuration {
+
+        private ConfigurationProxy(ConfigurationImpl impl) {
+            super(impl);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConfigurationImpl)) {
+            return false;
+        }
+
+        ConfigurationImpl that = (ConfigurationImpl) o;
+
+        if (isEdgeWeightColumn() != that.isEdgeWeightColumn()) {
+            return false;
+        }
+        if (isEnableAutoLocking() != that.isEnableAutoLocking()) {
+            return false;
+        }
+        if (isEnableAutoEdgeTypeRegistration() != that.isEnableAutoEdgeTypeRegistration()) {
+            return false;
+        }
+        if (isEnableIndexNodes() != that.isEnableIndexNodes()) {
+            return false;
+        }
+        if (isEnableIndexEdges() != that.isEnableIndexEdges()) {
+            return false;
+        }
+        if (isEnableIndexTimestamps() != that.isEnableIndexTimestamps()) {
+            return false;
+        }
+        if (isEnableObservers() != that.isEnableObservers()) {
+            return false;
+        }
+        if (isEnableNodeProperties() != that.isEnableNodeProperties()) {
+            return false;
+        }
+        if (isEnableEdgeProperties() != that.isEnableEdgeProperties()) {
+            return false;
+        }
+        if (isEnableSpatialIndex() != that.isEnableSpatialIndex()) {
+            return false;
+        }
+        if (!getNodeIdType().equals(that.getNodeIdType())) {
+            return false;
+        }
+        if (!getEdgeIdType().equals(that.getEdgeIdType())) {
+            return false;
+        }
+        if (!getEdgeLabelType().equals(that.getEdgeLabelType())) {
+            return false;
+        }
+        if (!getEdgeWeightType().equals(that.getEdgeWeightType())) {
+            return false;
+        }
+        return getTimeRepresentation() == that.getTimeRepresentation();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getNodeIdType().hashCode();
+        result = 31 * result + getEdgeIdType().hashCode();
+        result = 31 * result + getEdgeLabelType().hashCode();
+        result = 31 * result + getEdgeWeightType().hashCode();
+        result = 31 * result + getTimeRepresentation().hashCode();
+        result = 31 * result + (isEdgeWeightColumn() ? 1 : 0);
+        result = 31 * result + (isEnableAutoLocking() ? 1 : 0);
+        result = 31 * result + (isEnableAutoEdgeTypeRegistration() ? 1 : 0);
+        result = 31 * result + (isEnableIndexNodes() ? 1 : 0);
+        result = 31 * result + (isEnableIndexEdges() ? 1 : 0);
+        result = 31 * result + (isEnableIndexTimestamps() ? 1 : 0);
+        result = 31 * result + (isEnableObservers() ? 1 : 0);
+        result = 31 * result + (isEnableNodeProperties() ? 1 : 0);
+        result = 31 * result + (isEnableEdgeProperties() ? 1 : 0);
+        result = 31 * result + (isEnableSpatialIndex() ? 1 : 0);
+        return result;
+    }
+}

--- a/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
@@ -33,6 +33,8 @@ public class ConfigurationImpl {
     private final boolean enableEdgeProperties;
     // Enable spatial index (default False)
     private final boolean enableSpatialIndex;
+    // Enable parallel edges of the same type
+    private final boolean enableParallelEdgesSameType;
 
     public ConfigurationImpl() {
         nodeIdType = GraphStoreConfiguration.DEFAULT_NODE_ID_TYPE;
@@ -50,6 +52,7 @@ public class ConfigurationImpl {
         enableNodeProperties = GraphStoreConfiguration.DEFAULT_ENABLE_NODE_PROPERTIES;
         enableEdgeProperties = GraphStoreConfiguration.DEFAULT_ENABLE_EDGE_PROPERTIES;
         enableSpatialIndex = GraphStoreConfiguration.DEFAULT_ENABLE_SPATIAL_INDEX;
+        enableParallelEdgesSameType = GraphStoreConfiguration.DEFAULT_ENABLE_PARALLEL_EDGES_SAME_TYPE;
     }
 
     public ConfigurationImpl(Configuration configuration) {
@@ -68,6 +71,7 @@ public class ConfigurationImpl {
         enableNodeProperties = configuration.isEnableNodeProperties();
         enableEdgeProperties = configuration.isEnableEdgeProperties();
         enableSpatialIndex = configuration.isEnableSpatialIndex();
+        enableParallelEdgesSameType = configuration.isEnableParallelEdgesSameType();
     }
 
     public Configuration toConfiguration() {
@@ -134,6 +138,10 @@ public class ConfigurationImpl {
         return enableSpatialIndex;
     }
 
+    public boolean isEnableParallelEdgesSameType() {
+        return enableParallelEdgesSameType;
+    }
+
     // Used to return a Configuration instance
     private static class ConfigurationProxy extends Configuration {
 
@@ -183,6 +191,9 @@ public class ConfigurationImpl {
         if (isEnableSpatialIndex() != that.isEnableSpatialIndex()) {
             return false;
         }
+        if (isEnableParallelEdgesSameType() != that.isEnableParallelEdgesSameType()) {
+            return false;
+        }
         if (!getNodeIdType().equals(that.getNodeIdType())) {
             return false;
         }
@@ -215,6 +226,7 @@ public class ConfigurationImpl {
         result = 31 * result + (isEnableNodeProperties() ? 1 : 0);
         result = 31 * result + (isEnableEdgeProperties() ? 1 : 0);
         result = 31 * result + (isEnableSpatialIndex() ? 1 : 0);
+        result = 31 * result + (isEnableParallelEdgesSameType() ? 1 : 0);
         return result;
     }
 }

--- a/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
@@ -27,7 +27,7 @@ public class ConfigurationImpl {
     // Enable reverse index for edge attributes (default True)
     private final boolean enableIndexEdges;
     // Enable reverse index for timestamps (default True)
-    private final boolean enableIndexTimestamps;
+    private final boolean enableIndexTime;
     // Enable observers (default True)
     private final boolean enableObservers;
     // Node properties are X, Y, Color etc. (default True)
@@ -50,7 +50,7 @@ public class ConfigurationImpl {
         enableAutoEdgeTypeRegistration = GraphStoreConfiguration.DEFAULT_ENABLE_AUTO_EDGE_TYPE_REGISTRATION;
         enableIndexNodes = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_NODES;
         enableIndexEdges = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_EDGES;
-        enableIndexTimestamps = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_TIMESTAMP;
+        enableIndexTime = GraphStoreConfiguration.DEFAULT_ENABLE_INDEX_TIME;
         enableObservers = GraphStoreConfiguration.DEFAULT_ENABLE_OBSERVERS;
         enableNodeProperties = GraphStoreConfiguration.DEFAULT_ENABLE_NODE_PROPERTIES;
         enableEdgeProperties = GraphStoreConfiguration.DEFAULT_ENABLE_EDGE_PROPERTIES;
@@ -69,7 +69,7 @@ public class ConfigurationImpl {
         enableAutoEdgeTypeRegistration = configuration.isEnableAutoEdgeTypeRegistration();
         enableIndexNodes = configuration.isEnableIndexNodes();
         enableIndexEdges = configuration.isEnableIndexEdges();
-        enableIndexTimestamps = configuration.isEnableIndexTimestamps();
+        enableIndexTime = configuration.isEnableIndexTime();
         enableObservers = configuration.isEnableObservers();
         enableNodeProperties = configuration.isEnableNodeProperties();
         enableEdgeProperties = configuration.isEnableEdgeProperties();
@@ -121,8 +121,8 @@ public class ConfigurationImpl {
         return enableIndexEdges;
     }
 
-    public boolean isEnableIndexTimestamps() {
-        return enableIndexTimestamps;
+    public boolean isEnableIndexTime() {
+        return enableIndexTime;
     }
 
     public boolean isEnableObservers() {
@@ -179,7 +179,7 @@ public class ConfigurationImpl {
         if (isEnableIndexEdges() != that.isEnableIndexEdges()) {
             return false;
         }
-        if (isEnableIndexTimestamps() != that.isEnableIndexTimestamps()) {
+        if (isEnableIndexTime() != that.isEnableIndexTime()) {
             return false;
         }
         if (isEnableObservers() != that.isEnableObservers()) {
@@ -224,7 +224,7 @@ public class ConfigurationImpl {
         result = 31 * result + (isEnableAutoEdgeTypeRegistration() ? 1 : 0);
         result = 31 * result + (isEnableIndexNodes() ? 1 : 0);
         result = 31 * result + (isEnableIndexEdges() ? 1 : 0);
-        result = 31 * result + (isEnableIndexTimestamps() ? 1 : 0);
+        result = 31 * result + (isEnableIndexTime() ? 1 : 0);
         result = 31 * result + (isEnableObservers() ? 1 : 0);
         result = 31 * result + (isEnableNodeProperties() ? 1 : 0);
         result = 31 * result + (isEnableEdgeProperties() ? 1 : 0);

--- a/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
+++ b/src/main/java/org/gephi/graph/impl/ConfigurationImpl.java
@@ -17,7 +17,8 @@ public class ConfigurationImpl {
     private final TimeRepresentation timeRepresentation;
     // Use edge weight column, or just double (default True)
     private final boolean edgeWeightColumn;
-    // Automatically use read/write locks when iterating/writing graph elements (default True)
+    // Automatically use read/write locks when iterating/writing graph elements
+    // (default True)
     private final boolean enableAutoLocking;
     // Automatically register edge types when adding elements (default True)
     private final boolean enableAutoEdgeTypeRegistration;
@@ -25,7 +26,9 @@ public class ConfigurationImpl {
     private final boolean enableIndexNodes;
     // Enable reverse index for edge attributes (default True)
     private final boolean enableIndexEdges;
+    // Enable reverse index for timestamps (default True)
     private final boolean enableIndexTimestamps;
+    // Enable observers (default True)
     private final boolean enableObservers;
     // Node properties are X, Y, Color etc. (default True)
     private final boolean enableNodeProperties;
@@ -33,7 +36,7 @@ public class ConfigurationImpl {
     private final boolean enableEdgeProperties;
     // Enable spatial index (default False)
     private final boolean enableSpatialIndex;
-    // Enable parallel edges of the same type
+    // Enable parallel edges of the same type (default True)
     private final boolean enableParallelEdgesSameType;
 
     public ConfigurationImpl() {

--- a/src/main/java/org/gephi/graph/impl/DefaultColumnsImpl.java
+++ b/src/main/java/org/gephi/graph/impl/DefaultColumnsImpl.java
@@ -12,8 +12,8 @@ public class DefaultColumnsImpl implements GraphModel.DefaultColumns {
     protected final GraphStore store;
 
     // Default columns (initialised at store creation)
-    protected TableDefaultColumns<Node> nodeDefaultColumns;
-    protected TableDefaultColumns<Edge> edgeDefaultColumns;
+    protected final TableDefaultColumns<Node> nodeDefaultColumns;
+    protected final TableDefaultColumns<Edge> edgeDefaultColumns;
 
     // Extra columns (temporary solution, until they are fully added as normal
     // columns)
@@ -35,11 +35,6 @@ public class DefaultColumnsImpl implements GraphModel.DefaultColumns {
                 Integer.class, "Out-Degree", null, Origin.PROPERTY, false, true);
         typeColumn = new ColumnImpl(store.edgeTable, GraphStoreConfiguration.EDGE_TYPE_COLUMN_ID, Integer.class, "Type",
                 null, Origin.PROPERTY, false, true);
-    }
-
-    public void resetConfiguration() {
-        this.nodeDefaultColumns = new TableDefaultColumns<>(store.nodeTable);
-        this.edgeDefaultColumns = new TableDefaultColumns<>(store.edgeTable);
     }
 
     @Override

--- a/src/main/java/org/gephi/graph/impl/DefaultColumnsImpl.java
+++ b/src/main/java/org/gephi/graph/impl/DefaultColumnsImpl.java
@@ -37,6 +37,25 @@ public class DefaultColumnsImpl implements GraphModel.DefaultColumns {
                 null, Origin.PROPERTY, false, true);
     }
 
+    // Used by serialization
+    protected ColumnImpl getColumn(TableImpl table, int storeId) {
+        TableDefaultColumns<? extends Element> defaultColumns = table.isNodeTable() ? nodeDefaultColumns
+                : edgeDefaultColumns;
+        switch (storeId) {
+            case GraphStoreConfiguration.ELEMENT_ID_INDEX:
+                return defaultColumns.id;
+            case GraphStoreConfiguration.ELEMENT_LABEL_INDEX:
+                return defaultColumns.label;
+            case GraphStoreConfiguration.ELEMENT_TIMESET_INDEX:
+                return defaultColumns.timeset;
+        }
+
+        if (table.isEdgeTable() && storeId == GraphStoreConfiguration.EDGE_WEIGHT_INDEX) {
+            return store.edgeTable.getColumn(storeId);
+        }
+        return null;
+    }
+
     @Override
     public Column nodeId() {
         return nodeDefaultColumns.id;

--- a/src/main/java/org/gephi/graph/impl/EdgeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeImpl.java
@@ -53,8 +53,8 @@ public class EdgeImpl extends ElementImpl implements Edge {
         this.target = target;
         this.flags = (byte) (directed ? 1 : 0);
         this.type = type;
-        this.properties = graphStore == null
-            || graphStore.configuration.isEnableEdgeProperties() ? new EdgePropertiesImpl() : null;
+        this.properties = graphStore == null || graphStore.configuration.isEnableEdgeProperties()
+                ? new EdgePropertiesImpl() : null;
         if (graphStore == null || graphStore.configuration.getEdgeWeightType().equals(Double.class)) {
             this.attributes.setAttribute(GraphStoreConfiguration.EDGE_WEIGHT_INDEX, weight);
         }

--- a/src/main/java/org/gephi/graph/impl/EdgeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeImpl.java
@@ -18,15 +18,11 @@ package org.gephi.graph.impl;
 import java.awt.Color;
 import java.util.Map;
 import org.gephi.graph.api.Column;
-import org.gephi.graph.api.Estimator;
 import org.gephi.graph.api.Interval;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.EdgeProperties;
 import org.gephi.graph.api.GraphView;
 import org.gephi.graph.api.Table;
-import org.gephi.graph.api.types.IntervalMap;
-import org.gephi.graph.api.types.TimeMap;
-import org.gephi.graph.api.types.TimestampMap;
 import static org.gephi.graph.impl.GraphStoreConfiguration.DEFAULT_DYNAMIC_EDGE_WEIGHT_WHEN_MISSING;
 
 public class EdgeImpl extends ElementImpl implements Edge {
@@ -57,7 +53,8 @@ public class EdgeImpl extends ElementImpl implements Edge {
         this.target = target;
         this.flags = (byte) (directed ? 1 : 0);
         this.type = type;
-        this.properties = GraphStoreConfiguration.ENABLE_EDGE_PROPERTIES ? new EdgePropertiesImpl() : null;
+        this.properties = graphStore == null
+            || graphStore.configuration.isEnableEdgeProperties() ? new EdgePropertiesImpl() : null;
         if (graphStore == null || graphStore.configuration.getEdgeWeightType().equals(Double.class)) {
             this.attributes.setAttribute(GraphStoreConfiguration.EDGE_WEIGHT_INDEX, weight);
         }

--- a/src/main/java/org/gephi/graph/impl/EdgeStore.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeStore.java
@@ -49,6 +49,8 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
     protected final GraphViewStore viewStore;
     // Spatial index
     protected final SpatialIndexImpl spatialIndex;
+    // Configuration
+    protected final ConfigurationImpl configuration;
     // Data
     protected int size;
     protected int garbageSize;
@@ -70,15 +72,17 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
         this.viewStore = null;
         this.version = null;
         this.spatialIndex = null;
+        this.configuration = new ConfigurationImpl();
     }
 
-    public EdgeStore(final EdgeTypeStore edgeTypeStore, final SpatialIndexImpl spatialIndex, final GraphLockImpl lock, final GraphViewStore viewStore, final GraphVersion graphVersion) {
+    public EdgeStore(final EdgeTypeStore edgeTypeStore, final SpatialIndexImpl spatialIndex, final ConfigurationImpl configuration, final GraphLockImpl lock, final GraphViewStore viewStore, final GraphVersion graphVersion) {
         initStore();
         this.lock = lock;
         this.edgeTypeStore = edgeTypeStore;
         this.viewStore = viewStore;
         this.version = graphVersion;
         this.spatialIndex = spatialIndex;
+        this.configuration = configuration == null ? new ConfigurationImpl() : configuration;
     }
 
     protected static long getLongId(NodeImpl source, NodeImpl target, boolean directed) {
@@ -574,7 +578,7 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
 
             long longId = getLongId(edge.source, edge.target, edge.isDirected());
             int[] newDicoValue = newDico.get(longId);
-            if (newDicoValue != null) {
+            if (newDicoValue != null && !configuration.isEnableParallelEdgesSameType()) {
                 return false;
             }
 
@@ -693,7 +697,7 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
             Long2ObjectOpenCustomHashMap<int[]> dico = longDictionary[type];
             long longId = getLongId(source, target, directed);
             int[] dicoValue = dico.get(longId);
-            if (dicoValue != null) {
+            if (dicoValue != null && !configuration.isEnableParallelEdgesSameType()) {
                 return false;
             }
 

--- a/src/main/java/org/gephi/graph/impl/EdgeStore.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeStore.java
@@ -574,7 +574,7 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
 
             long longId = getLongId(edge.source, edge.target, edge.isDirected());
             int[] newDicoValue = newDico.get(longId);
-            if (newDicoValue != null && !GraphStoreConfiguration.ENABLE_PARALLEL_EDGES) {
+            if (newDicoValue != null) {
                 return false;
             }
 
@@ -693,7 +693,7 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
             Long2ObjectOpenCustomHashMap<int[]> dico = longDictionary[type];
             long longId = getLongId(source, target, directed);
             int[] dicoValue = dico.get(longId);
-            if (dicoValue != null && !GraphStoreConfiguration.ENABLE_PARALLEL_EDGES) {
+            if (dicoValue != null) {
                 return false;
             }
 

--- a/src/main/java/org/gephi/graph/impl/EdgeStore.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeStore.java
@@ -701,6 +701,9 @@ public class EdgeStore implements Collection<Edge>, EdgeIterable {
                 return false;
             }
 
+            if (edgeTypeStore != null) {
+                edgeTypeStore.registerEdgeType(type);
+            }
             incrementVersion();
 
             if (garbageSize > 0) {

--- a/src/main/java/org/gephi/graph/impl/EdgeTypeStore.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeTypeStore.java
@@ -34,17 +34,17 @@ public class EdgeTypeStore {
     // Config
     public final static int MAX_SIZE = 65534;
     // Data
-    protected final Configuration configuration;
+    protected final ConfigurationImpl configuration;
     protected final Object2ShortMap labelMap;
     protected final Short2ObjectMap idMap;
     protected final ShortSortedSet garbageQueue;
     protected int length;
 
     public EdgeTypeStore() {
-        this(new Configuration());
+        this(new ConfigurationImpl());
     }
 
-    public EdgeTypeStore(Configuration config) {
+    public EdgeTypeStore(ConfigurationImpl config) {
         if (MAX_SIZE >= Short.MAX_VALUE - Short.MIN_VALUE + 1) {
             throw new RuntimeException("Edge Type Store size can't exceed 65534");
         }
@@ -78,10 +78,10 @@ public class EdgeTypeStore {
 
     public void registerEdgeType(int type) {
         if (!contains(type)) {
-            if (GraphStoreConfiguration.ENABLE_AUTO_TYPE_REGISTRATION) {
+            if (configuration.isEnableAutoEdgeTypeRegistration()) {
                 addType(String.valueOf(type), type);
             } else {
-                throw new RuntimeException("The type doesn't exist");
+                throw new UnsupportedOperationException("The type "+type+" doesn't exist, and edge type auto registration is disabled (from Configuration)");
             }
         }
     }

--- a/src/main/java/org/gephi/graph/impl/EdgeTypeStore.java
+++ b/src/main/java/org/gephi/graph/impl/EdgeTypeStore.java
@@ -81,7 +81,8 @@ public class EdgeTypeStore {
             if (configuration.isEnableAutoEdgeTypeRegistration()) {
                 addType(String.valueOf(type), type);
             } else {
-                throw new UnsupportedOperationException("The type "+type+" doesn't exist, and edge type auto registration is disabled (from Configuration)");
+                throw new UnsupportedOperationException(
+                        "The type " + type + " doesn't exist, and edge type auto registration is disabled (from Configuration)");
             }
         }
     }

--- a/src/main/java/org/gephi/graph/impl/GraphBridgeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphBridgeImpl.java
@@ -258,32 +258,40 @@ public class GraphBridgeImpl implements GraphBridge {
 
         // Time representation
         if (!destConfig.getTimeRepresentation().equals(sourceConfig.getTimeRepresentation())) {
-            throw new RuntimeException("The time representations doesn't match, source: " + sourceConfig.getTimeRepresentation() + ", destination: " + destConfig.getTimeRepresentation());
+            throw new RuntimeException("The time representations doesn't match, source: " + sourceConfig
+                    .getTimeRepresentation() + ", destination: " + destConfig.getTimeRepresentation());
         }
 
         // Node id type
         if (!destConfig.getNodeIdType().equals(sourceConfig.getNodeIdType())) {
-            throw new RuntimeException("The node id type doesn't match, source: " + sourceConfig.getNodeIdType() + ", destination: " + destConfig.getNodeIdType());
+            throw new RuntimeException("The node id type doesn't match, source: " + sourceConfig
+                    .getNodeIdType() + ", destination: " + destConfig.getNodeIdType());
         }
 
         // Edge id type
         if (!destConfig.getEdgeIdType().equals(sourceConfig.getEdgeIdType())) {
-            throw new RuntimeException("The edge id type doesn't match, source: " + sourceConfig.getEdgeIdType() + ", destination: " + destConfig.getEdgeIdType());
+            throw new RuntimeException("The edge id type doesn't match, source: " + sourceConfig
+                    .getEdgeIdType() + ", destination: " + destConfig.getEdgeIdType());
         }
 
         // Edge weight type
         if (!destConfig.getEdgeWeightType().equals(sourceConfig.getEdgeWeightType())) {
-            throw new RuntimeException("The edge weight type doesn't match, source: " + sourceConfig.getEdgeWeightType() + ", destination: " + destConfig.getEdgeWeightType());
+            throw new RuntimeException("The edge weight type doesn't match, source: " + sourceConfig
+                    .getEdgeWeightType() + ", destination: " + destConfig.getEdgeWeightType());
         }
 
         // Edge label type
         if (!destConfig.getEdgeLabelType().equals(sourceConfig.getEdgeLabelType())) {
-            throw new RuntimeException("The edge label type doesn't match, source: " + sourceConfig.getEdgeLabelType() + ", destination: " + destConfig.getEdgeLabelType());
+            throw new RuntimeException("The edge label type doesn't match, source: " + sourceConfig
+                    .getEdgeLabelType() + ", destination: " + destConfig.getEdgeLabelType());
         }
 
         // Parallel edges
         if (destConfig.isEnableParallelEdgesSameType() != sourceConfig.isEnableParallelEdgesSameType()) {
-            throw new RuntimeException("The parallel edges of same type configuration doesn't match, source: " + sourceConfig.isEnableParallelEdgesSameType() + ", destination: " + destConfig.isEnableParallelEdgesSameType());
+            throw new RuntimeException(
+                    "The parallel edges of same type configuration doesn't match, source: " + sourceConfig
+                            .isEnableParallelEdgesSameType() + ", destination: " + destConfig
+                                    .isEnableParallelEdgesSameType());
         }
 
         // Verify node table

--- a/src/main/java/org/gephi/graph/impl/GraphBridgeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphBridgeImpl.java
@@ -257,7 +257,7 @@ public class GraphBridgeImpl implements GraphBridge {
         ConfigurationImpl sourceConfig = sourceStore.configuration;
 
         // Time representation
-        if (sourceStore.graphModel.isDynamic() && !destConfig.getTimeRepresentation().equals(sourceConfig.getTimeRepresentation())) {
+        if (!destConfig.getTimeRepresentation().equals(sourceConfig.getTimeRepresentation())) {
             throw new RuntimeException("The time representations doesn't match, source: " + sourceConfig.getTimeRepresentation() + ", destination: " + destConfig.getTimeRepresentation());
         }
 
@@ -279,6 +279,11 @@ public class GraphBridgeImpl implements GraphBridge {
         // Edge label type
         if (!destConfig.getEdgeLabelType().equals(sourceConfig.getEdgeLabelType())) {
             throw new RuntimeException("The edge label type doesn't match, source: " + sourceConfig.getEdgeLabelType() + ", destination: " + destConfig.getEdgeLabelType());
+        }
+
+        // Parallel edges
+        if (destConfig.isEnableParallelEdgesSameType() != sourceConfig.isEnableParallelEdgesSameType()) {
+            throw new RuntimeException("The parallel edges of same type configuration doesn't match, source: " + sourceConfig.isEnableParallelEdgesSameType() + ", destination: " + destConfig.isEnableParallelEdgesSameType());
         }
 
         // Verify node table

--- a/src/main/java/org/gephi/graph/impl/GraphBridgeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphBridgeImpl.java
@@ -97,14 +97,17 @@ public class GraphBridgeImpl implements GraphBridge {
             if (store.getNode(node.getId()) == null) {
                 Node nodeCopy = factory.newNode(node.getId());
 
+                // Label
+                copyLabel(node, nodeCopy);
+
                 // Time set
                 copyTimeSet(node, nodeCopy);
 
                 // Properties
-                copyNodeProperties(node, nodeCopy);
-
-                // Text properties
-                copyTextProperties(node.getTextProperties(), nodeCopy.getTextProperties());
+                if (store.configuration.isEnableNodeProperties()) {
+                    copyNodeProperties(node, nodeCopy);
+                    copyTextProperties(node.getTextProperties(), nodeCopy.getTextProperties());
+                }
 
                 // Attributes
                 copyAttributes(sourceStore.nodeTable, nodeTable, node, nodeCopy);
@@ -122,6 +125,9 @@ public class GraphBridgeImpl implements GraphBridge {
 
                 Edge edgeCopy = factory.newEdge(edge.getId(), source, target, edge.getType(), 0.0, edge.isDirected());
 
+                // Label
+                copyLabel(edge, edgeCopy);
+
                 // Time set
                 copyTimeSet(edge, edgeCopy);
 
@@ -129,10 +135,10 @@ public class GraphBridgeImpl implements GraphBridge {
                 copyEdgeWeight(edge, edgeCopy);
 
                 // Properties
-                copyEdgeProperties(edge, edgeCopy);
-
-                // Text properties
-                copyTextProperties(edge.getTextProperties(), edgeCopy.getTextProperties());
+                if (store.configuration.isEnableEdgeProperties()) {
+                    copyEdgeProperties(edge, edgeCopy);
+                    copyTextProperties(edge.getTextProperties(), edgeCopy.getTextProperties());
+                }
 
                 // Attributes
                 copyAttributes(sourceStore.edgeTable, edgeTable, edge, edgeCopy);
@@ -164,13 +170,15 @@ public class GraphBridgeImpl implements GraphBridge {
         nodeCopy.setPosition(node.x(), node.y(), node.z());
         nodeCopy.setColor(node.getColor());
         nodeCopy.setFixed(node.isFixed());
-        nodeCopy.setLabel(node.getLabel());
         nodeCopy.setSize(node.size());
+    }
+
+    private void copyLabel(Element element, Element elementCopy) {
+        elementCopy.setLabel(element.getLabel());
     }
 
     private void copyEdgeProperties(Edge edge, Edge edgeCopy) {
         edgeCopy.setColor(edge.getColor());
-        edgeCopy.setLabel(edge.getLabel());
     }
 
     private void copyTextProperties(TextProperties text, TextProperties textCopy) {
@@ -195,7 +203,7 @@ public class GraphBridgeImpl implements GraphBridge {
     }
 
     private void copyAttributes(TableImpl sourceTable, TableImpl destTable, Element element, Element elementCopy) {
-        TimeRepresentation tr = sourceTable.store.configuration.getTimeRepresentation();
+        TimeRepresentation tr = sourceTable.store.graphStore.configuration.getTimeRepresentation();
         for (Column col : sourceTable.toArray()) {
             if (!col.isProperty()) {
                 Column colCopy = destTable.getColumn(col.getId());
@@ -245,10 +253,32 @@ public class GraphBridgeImpl implements GraphBridge {
 
     private void verifyCompatibility(GraphStore sourceStore) {
         // Verify configuration
-        Configuration destConfig = store.configuration;
-        Configuration sourceConfig = sourceStore.configuration;
-        if (!destConfig.equals(sourceConfig)) {
-            throw new RuntimeException("The configurations don't match");
+        ConfigurationImpl destConfig = store.configuration;
+        ConfigurationImpl sourceConfig = sourceStore.configuration;
+
+        // Time representation
+        if (sourceStore.graphModel.isDynamic() && !destConfig.getTimeRepresentation().equals(sourceConfig.getTimeRepresentation())) {
+            throw new RuntimeException("The time representations doesn't match, source: " + sourceConfig.getTimeRepresentation() + ", destination: " + destConfig.getTimeRepresentation());
+        }
+
+        // Node id type
+        if (!destConfig.getNodeIdType().equals(sourceConfig.getNodeIdType())) {
+            throw new RuntimeException("The node id type doesn't match, source: " + sourceConfig.getNodeIdType() + ", destination: " + destConfig.getNodeIdType());
+        }
+
+        // Edge id type
+        if (!destConfig.getEdgeIdType().equals(sourceConfig.getEdgeIdType())) {
+            throw new RuntimeException("The edge id type doesn't match, source: " + sourceConfig.getEdgeIdType() + ", destination: " + destConfig.getEdgeIdType());
+        }
+
+        // Edge weight type
+        if (!destConfig.getEdgeWeightType().equals(sourceConfig.getEdgeWeightType())) {
+            throw new RuntimeException("The edge weight type doesn't match, source: " + sourceConfig.getEdgeWeightType() + ", destination: " + destConfig.getEdgeWeightType());
+        }
+
+        // Edge label type
+        if (!destConfig.getEdgeLabelType().equals(sourceConfig.getEdgeLabelType())) {
+            throw new RuntimeException("The edge label type doesn't match, source: " + sourceConfig.getEdgeLabelType() + ", destination: " + destConfig.getEdgeLabelType());
         }
 
         // Verify node table

--- a/src/main/java/org/gephi/graph/impl/GraphFactoryImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphFactoryImpl.java
@@ -30,8 +30,8 @@ public class GraphFactoryImpl implements GraphFactory {
     protected final AtomicInteger NODE_IDS = new AtomicInteger();
     protected final AtomicInteger EDGE_IDS = new AtomicInteger();
     // Config
-    protected AssignConfiguration nodeAssignConfiguration;
-    protected AssignConfiguration edgeAssignConfiguration;
+    protected final AssignConfiguration nodeAssignConfiguration;
+    protected final AssignConfiguration edgeAssignConfiguration;
     // Store
     protected final GraphStore store;
 
@@ -205,13 +205,6 @@ public class GraphFactoryImpl implements GraphFactory {
             return false;
         }
         return true;
-    }
-
-    public void resetConfiguration() {
-        this.nodeAssignConfiguration = getAssignConfiguration(AttributeUtils
-                .getStandardizedType(store.configuration.getNodeIdType()));
-        this.edgeAssignConfiguration = getAssignConfiguration(AttributeUtils
-                .getStandardizedType(store.configuration.getEdgeIdType()));
     }
 
     protected final AssignConfiguration getAssignConfiguration(Class type) {

--- a/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
@@ -446,7 +446,8 @@ public class GraphModelImpl implements GraphModel {
 
     @Override
     public void setConfiguration(Configuration config) {
-        throw new UnsupportedOperationException("No longer supported. Configuration is immutable and needs to be passed at GraphModel creation time");
+        throw new UnsupportedOperationException(
+                "No longer supported. Configuration is immutable and needs to be passed at GraphModel creation time");
     }
 
     @Override

--- a/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -173,9 +173,6 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     public boolean addEdge(final Edge edge) {
         autoWriteLock();
         try {
-            if (edgeTypeStore != null) {
-                edgeTypeStore.registerEdgeType(edge.getType());
-            }
             return edgeStore.add(edge);
         } finally {
             autoWriteUnlock();
@@ -186,11 +183,6 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     public boolean addAllEdges(Collection<? extends Edge> edges) {
         autoWriteLock();
         try {
-            for (Edge edge : edges) {
-                if (edgeTypeStore != null) {
-                    edgeTypeStore.registerEdgeType(edge.getType());
-                }
-            }
             return edgeStore.addAll(edges);
         } finally {
             autoWriteUnlock();

--- a/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -103,9 +103,9 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         spatialIndex = configuration.isEnableSpatialIndex() ? new SpatialIndexImpl(this) : null;
         edgeStore = new EdgeStore(edgeTypeStore, spatialIndex, configuration,
                 configuration.isEnableAutoLocking() ? lock : null, viewStore,
-            configuration.isEnableObservers() ? version : null);
-        nodeStore = new NodeStore(edgeStore, spatialIndex, configuration.isEnableAutoLocking() ? lock : null,
-                viewStore, configuration.isEnableObservers() ? version : null);
+                configuration.isEnableObservers() ? version : null);
+        nodeStore = new NodeStore(edgeStore, spatialIndex, configuration.isEnableAutoLocking() ? lock : null, viewStore,
+                configuration.isEnableObservers() ? version : null);
         nodeTable = new TableImpl<>(this, Node.class);
         edgeTable = new TableImpl<>(this, Edge.class);
         timeStore = new TimeStore(this, configuration.isEnableIndexTimestamps());
@@ -839,13 +839,11 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     }
 
     protected EdgeIterableWrapper getEdgeIterableWrapper(Iterator<Edge> edgeIterator, boolean blocking) {
-        return new EdgeIterableWrapper(edgeIterator,
-                (blocking && configuration.isEnableAutoLocking()) ? lock : null);
+        return new EdgeIterableWrapper(edgeIterator, (blocking && configuration.isEnableAutoLocking()) ? lock : null);
     }
 
     protected NodeIterableWrapper getNodeIterableWrapper(Iterator<Node> nodeIterator, boolean blocking) {
-        return new NodeIterableWrapper(nodeIterator,
-                (blocking && configuration.isEnableAutoLocking()) ? lock : null);
+        return new NodeIterableWrapper(nodeIterator, (blocking && configuration.isEnableAutoLocking()) ? lock : null);
     }
 
     public int deepHashCode() {

--- a/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -101,7 +101,7 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         version = configuration.isEnableObservers() ? new GraphVersion(this) : null;
         observers = configuration.isEnableObservers() ? new ArrayList<>() : null;
         spatialIndex = configuration.isEnableSpatialIndex() ? new SpatialIndexImpl(this) : null;
-        edgeStore = new EdgeStore(edgeTypeStore, spatialIndex,
+        edgeStore = new EdgeStore(edgeTypeStore, spatialIndex, configuration,
                 configuration.isEnableAutoLocking() ? lock : null, viewStore,
             configuration.isEnableObservers() ? version : null);
         nodeStore = new NodeStore(edgeStore, spatialIndex, configuration.isEnableAutoLocking() ? lock : null,

--- a/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -16,7 +16,6 @@
 
 package org.gephi.graph.impl;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import org.gephi.graph.api.AttributeUtils;
 import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.DirectedGraph;
 import org.gephi.graph.api.DirectedSubgraph;
@@ -108,7 +106,7 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
                 configuration.isEnableObservers() ? version : null);
         nodeTable = new TableImpl<>(this, Node.class);
         edgeTable = new TableImpl<>(this, Edge.class);
-        timeStore = new TimeStore(this, configuration.isEnableIndexTimestamps());
+        timeStore = new TimeStore(this, configuration.isEnableIndexTime());
         attributes = new GraphAttributesImpl();
         factory = new GraphFactoryImpl(this);
         timeFormat = GraphStoreConfiguration.DEFAULT_TIME_FORMAT;

--- a/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -48,7 +48,7 @@ import org.joda.time.DateTimeZone;
 public class GraphStore implements DirectedGraph, DirectedSubgraph {
 
     protected final GraphModelImpl graphModel;
-    protected final Configuration configuration;
+    protected final ConfigurationImpl configuration;
     // Stores
     protected final NodeStore nodeStore;
     protected final EdgeStore edgeStore;
@@ -79,28 +79,36 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     protected final DefaultColumnsImpl defaultColumns;
 
     public GraphStore() {
-        this(null);
+        this(null, new ConfigurationImpl());
     }
 
     public GraphStore(GraphModelImpl model) {
-        configuration = model != null ? model.configuration : new Configuration();
+        this(model, model.configuration);
+    }
+
+    protected GraphStore(GraphModelImpl model, Configuration config) {
+        this(model, new ConfigurationImpl(config));
+    }
+
+    protected GraphStore(GraphModelImpl model, ConfigurationImpl config) {
+        configuration = config;
         graphModel = model;
         lock = new GraphLockImpl();
 
         edgeTypeStore = new EdgeTypeStore();
         mainGraphView = new MainGraphView();
         viewStore = new GraphViewStore(this);
-        version = GraphStoreConfiguration.ENABLE_OBSERVERS ? new GraphVersion(this) : null;
-        observers = GraphStoreConfiguration.ENABLE_OBSERVERS ? new ArrayList<>() : null;
-        spatialIndex = GraphStoreConfiguration.ENABLE_SPATIAL_INDEX ? new SpatialIndexImpl(this) : null;
+        version = configuration.isEnableObservers() ? new GraphVersion(this) : null;
+        observers = configuration.isEnableObservers() ? new ArrayList<>() : null;
+        spatialIndex = configuration.isEnableSpatialIndex() ? new SpatialIndexImpl(this) : null;
         edgeStore = new EdgeStore(edgeTypeStore, spatialIndex,
-                GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? lock : null, viewStore,
-                GraphStoreConfiguration.ENABLE_OBSERVERS ? version : null);
-        nodeStore = new NodeStore(edgeStore, spatialIndex, GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? lock : null,
-                viewStore, GraphStoreConfiguration.ENABLE_OBSERVERS ? version : null);
-        nodeTable = new TableImpl<>(this, Node.class, GraphStoreConfiguration.ENABLE_INDEX_NODES);
-        edgeTable = new TableImpl<>(this, Edge.class, GraphStoreConfiguration.ENABLE_INDEX_EDGES);
-        timeStore = new TimeStore(this, GraphStoreConfiguration.ENABLE_INDEX_TIMESTAMP);
+                configuration.isEnableAutoLocking() ? lock : null, viewStore,
+            configuration.isEnableObservers() ? version : null);
+        nodeStore = new NodeStore(edgeStore, spatialIndex, configuration.isEnableAutoLocking() ? lock : null,
+                viewStore, configuration.isEnableObservers() ? version : null);
+        nodeTable = new TableImpl<>(this, Node.class);
+        edgeTable = new TableImpl<>(this, Edge.class);
+        timeStore = new TimeStore(this, configuration.isEnableIndexTimestamps());
         attributes = new GraphAttributesImpl();
         factory = new GraphFactoryImpl(this);
         timeFormat = GraphStoreConfiguration.DEFAULT_TIME_FORMAT;
@@ -132,10 +140,9 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
                         IntervalSet.class, "Interval", null, Origin.PROPERTY, false, false));
             }
         }
-        if (configuration.getEdgeWeightColumn()) {
-            final boolean edgeWeightIndexed = AttributeUtils.isSimpleType(configuration.getEdgeWeightType());
+        if (configuration.isEdgeWeightColumn()) {
             edgeTable.store.addColumn(new ColumnImpl(edgeTable, GraphStoreConfiguration.EDGE_WEIGHT_COLUMN_ID,
-                    configuration.getEdgeWeightType(), "Weight", null, Origin.PROPERTY, edgeWeightIndexed, false));
+                    configuration.getEdgeWeightType(), "Weight", null, Origin.PROPERTY, false, false));
         } else {
             edgeTable.store.length++;
         }
@@ -705,31 +712,31 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
     }
 
     protected void autoReadLock() {
-        if (GraphStoreConfiguration.ENABLE_AUTO_LOCKING) {
+        if (configuration.isEnableAutoLocking()) {
             readLock();
         }
     }
 
     protected void autoReadUnlock() {
-        if (GraphStoreConfiguration.ENABLE_AUTO_LOCKING) {
+        if (configuration.isEnableAutoLocking()) {
             readUnlock();
         }
     }
 
     protected void autoReadUnlockAll() {
-        if (GraphStoreConfiguration.ENABLE_AUTO_LOCKING) {
+        if (configuration.isEnableAutoLocking()) {
             readUnlockAll();
         }
     }
 
     protected void autoWriteLock() {
-        if (GraphStoreConfiguration.ENABLE_AUTO_LOCKING) {
+        if (configuration.isEnableAutoLocking()) {
             writeLock();
         }
     }
 
     protected void autoWriteUnlock() {
-        if (GraphStoreConfiguration.ENABLE_AUTO_LOCKING) {
+        if (configuration.isEnableAutoLocking()) {
             writeUnlock();
         }
     }
@@ -833,12 +840,12 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
 
     protected EdgeIterableWrapper getEdgeIterableWrapper(Iterator<Edge> edgeIterator, boolean blocking) {
         return new EdgeIterableWrapper(edgeIterator,
-                (blocking && GraphStoreConfiguration.ENABLE_AUTO_LOCKING) ? lock : null);
+                (blocking && configuration.isEnableAutoLocking()) ? lock : null);
     }
 
     protected NodeIterableWrapper getNodeIterableWrapper(Iterator<Node> nodeIterator, boolean blocking) {
         return new NodeIterableWrapper(nodeIterator,
-                (blocking && GraphStoreConfiguration.ENABLE_AUTO_LOCKING) ? lock : null);
+                (blocking && configuration.isEnableAutoLocking()) ? lock : null);
     }
 
     public int deepHashCode() {

--- a/src/main/java/org/gephi/graph/impl/GraphStoreConfiguration.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStoreConfiguration.java
@@ -16,7 +16,6 @@
 package org.gephi.graph.impl;
 
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import org.gephi.graph.api.Estimator;
 import org.gephi.graph.api.TimeFormat;
 import org.gephi.graph.api.TimeRepresentation;
@@ -28,7 +27,7 @@ public final class GraphStoreConfiguration {
     public static final boolean DEFAULT_ENABLE_AUTO_EDGE_TYPE_REGISTRATION = true;
     public static final boolean DEFAULT_ENABLE_INDEX_NODES = true;
     public static final boolean DEFAULT_ENABLE_INDEX_EDGES = true;
-    public static final boolean DEFAULT_ENABLE_INDEX_TIMESTAMP = true;
+    public static final boolean DEFAULT_ENABLE_INDEX_TIME = true;
     public static final boolean DEFAULT_ENABLE_OBSERVERS = true;
     public static final boolean DEFAULT_ENABLE_NODE_PROPERTIES = true;
     public static final boolean DEFAULT_ENABLE_EDGE_PROPERTIES = true;

--- a/src/main/java/org/gephi/graph/impl/GraphStoreConfiguration.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStoreConfiguration.java
@@ -23,16 +23,16 @@ import org.joda.time.DateTimeZone;
 public final class GraphStoreConfiguration {
 
     // Features
-    public static final boolean ENABLE_AUTO_LOCKING = true;
-    public static final boolean ENABLE_AUTO_TYPE_REGISTRATION = true;
-    public static final boolean ENABLE_INDEX_NODES = true;
-    public static final boolean ENABLE_INDEX_EDGES = true;
-    public static final boolean ENABLE_INDEX_TIMESTAMP = true;
-    public static final boolean ENABLE_OBSERVERS = true;
-    public static final boolean ENABLE_NODE_PROPERTIES = true;
-    public static final boolean ENABLE_EDGE_PROPERTIES = true;
-    public static final boolean ENABLE_PARALLEL_EDGES = true;
-    public static final boolean ENABLE_SPATIAL_INDEX = false;
+    public static final boolean DEFAULT_ENABLE_AUTO_LOCKING = true;
+    public static final boolean DEFAULT_ENABLE_AUTO_EDGE_TYPE_REGISTRATION = true;
+    public static final boolean DEFAULT_ENABLE_INDEX_NODES = true;
+    public static final boolean DEFAULT_ENABLE_INDEX_EDGES = true;
+    public static final boolean DEFAULT_ENABLE_INDEX_TIMESTAMP = true;
+    public static final boolean DEFAULT_ENABLE_OBSERVERS = true;
+    public static final boolean DEFAULT_ENABLE_NODE_PROPERTIES = true;
+    public static final boolean DEFAULT_ENABLE_EDGE_PROPERTIES = true;
+    public static final boolean DEFAULT_ENABLE_SPATIAL_INDEX = false;
+    public static final boolean DEFAULT_ENABLE_EDGE_WEIGHT_COLUMN = true;
     // NodeStore
     public final static int NODESTORE_BLOCK_SIZE = 5000;
     public final static int NODESTORE_DEFAULT_BLOCKS = 10;

--- a/src/main/java/org/gephi/graph/impl/GraphStoreConfiguration.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStoreConfiguration.java
@@ -34,6 +34,7 @@ public final class GraphStoreConfiguration {
     public static final boolean DEFAULT_ENABLE_EDGE_PROPERTIES = true;
     public static final boolean DEFAULT_ENABLE_SPATIAL_INDEX = false;
     public static final boolean DEFAULT_ENABLE_EDGE_WEIGHT_COLUMN = true;
+    public static final boolean DEFAULT_ENABLE_PARALLEL_EDGES_SAME_TYPE = true;
     // NodeStore
     public final static int NODESTORE_BLOCK_SIZE = 5000;
     public final static int NODESTORE_DEFAULT_BLOCKS = 10;

--- a/src/main/java/org/gephi/graph/impl/NodeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/NodeImpl.java
@@ -36,8 +36,8 @@ public class NodeImpl extends ElementImpl implements Node {
     public NodeImpl(Object id, GraphStore graphStore) {
         super(id, graphStore);
         checkIdType(id);
-        this.properties = graphStore == null
-            || graphStore.configuration.isEnableNodeProperties() ? new NodePropertiesImpl() : null;
+        this.properties = graphStore == null || graphStore.configuration.isEnableNodeProperties()
+                ? new NodePropertiesImpl() : null;
     }
 
     public NodeImpl(Object id) {

--- a/src/main/java/org/gephi/graph/impl/NodeImpl.java
+++ b/src/main/java/org/gephi/graph/impl/NodeImpl.java
@@ -36,7 +36,8 @@ public class NodeImpl extends ElementImpl implements Node {
     public NodeImpl(Object id, GraphStore graphStore) {
         super(id, graphStore);
         checkIdType(id);
-        this.properties = GraphStoreConfiguration.ENABLE_NODE_PROPERTIES ? new NodePropertiesImpl() : null;
+        this.properties = graphStore == null
+            || graphStore.configuration.isEnableNodeProperties() ? new NodePropertiesImpl() : null;
     }
 
     public NodeImpl(Object id) {

--- a/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -259,27 +259,32 @@ public class Serialization {
     private void verifyCompatibility(ConfigurationImpl readConfig, ConfigurationImpl modelConfig) {
         // Time representation
         if (!readConfig.getTimeRepresentation().equals(modelConfig.getTimeRepresentation())) {
-            throw new RuntimeException("The time representations doesn't match, read: " + readConfig.getTimeRepresentation() + ", model: " + modelConfig.getTimeRepresentation());
+            throw new RuntimeException("The time representations doesn't match, read: " + readConfig
+                    .getTimeRepresentation() + ", model: " + modelConfig.getTimeRepresentation());
         }
 
         // Node id type
         if (!readConfig.getNodeIdType().equals(modelConfig.getNodeIdType())) {
-            throw new RuntimeException("The node id type doesn't match, read: " + readConfig.getNodeIdType() + ", model: " + modelConfig.getNodeIdType());
+            throw new RuntimeException("The node id type doesn't match, read: " + readConfig
+                    .getNodeIdType() + ", model: " + modelConfig.getNodeIdType());
         }
 
         // Edge id type
         if (!readConfig.getEdgeIdType().equals(modelConfig.getEdgeIdType())) {
-            throw new RuntimeException("The edge id type doesn't match, read: " + readConfig.getEdgeIdType() + ", model: " + modelConfig.getEdgeIdType());
+            throw new RuntimeException("The edge id type doesn't match, read: " + readConfig
+                    .getEdgeIdType() + ", model: " + modelConfig.getEdgeIdType());
         }
 
         // Edge weight type
         if (!readConfig.getEdgeWeightType().equals(modelConfig.getEdgeWeightType())) {
-            throw new RuntimeException("The edge weight type doesn't match, read: " + readConfig.getEdgeWeightType() + ", model: " + modelConfig.getEdgeWeightType());
+            throw new RuntimeException("The edge weight type doesn't match, read: " + readConfig
+                    .getEdgeWeightType() + ", model: " + modelConfig.getEdgeWeightType());
         }
 
         // Edge label type
         if (!readConfig.getEdgeLabelType().equals(modelConfig.getEdgeLabelType())) {
-            throw new RuntimeException("The edge label type doesn't match, read: " + readConfig.getEdgeLabelType() + ", model: " + modelConfig.getEdgeLabelType());
+            throw new RuntimeException("The edge label type doesn't match, read: " + readConfig
+                    .getEdgeLabelType() + ", model: " + modelConfig.getEdgeLabelType());
         }
     }
 
@@ -578,8 +583,7 @@ public class Serialization {
 
         ColumnImpl column = model.store.defaultColumns.getColumn(table, storeId);
         if (column == null) {
-            column = new ColumnImpl(table, (String) id, typeClass, title, defaultValue, origin, indexed,
-                readOnly);
+            column = new ColumnImpl(table, (String) id, typeClass, title, defaultValue, origin, indexed, readOnly);
             column.storeId = storeId;
         }
 
@@ -717,7 +721,7 @@ public class Serialization {
         boolean enableEdgeProperties = (Boolean) deserialize(is);
 
         graphStoreConfigurationVersion = new GraphStoreConfigurationVersion(enableElementLabel, enableElementTimestamp,
-            enableNodeProperties, enableEdgeProperties);
+                enableNodeProperties, enableEdgeProperties);
         return graphStoreConfigurationVersion;
     }
 

--- a/src/main/java/org/gephi/graph/impl/TableImpl.java
+++ b/src/main/java/org/gephi/graph/impl/TableImpl.java
@@ -34,12 +34,12 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
     // Store
     protected final ColumnStore<T> store;
 
-    public TableImpl(Class<T> elementType, boolean indexed) {
-        this(null, elementType, indexed);
+    public TableImpl(Class<T> elementType) {
+        this(null, elementType);
     }
 
-    public TableImpl(GraphStore graphStore, Class<T> elementType, boolean indexed) {
-        store = new ColumnStore<>(graphStore, elementType, indexed);
+    public TableImpl(GraphStore graphStore, Class<T> elementType) {
+        store = new ColumnStore<>(graphStore, elementType);
     }
 
     @Override
@@ -62,6 +62,7 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
         checkValidId(id);
         checkSupportedTypes(type);
         checkDefaultValue(defaultValue, type);
+        checkCanIndex(indexed);
 
         type = AttributeUtils.getStandardizedType(type);
         if (defaultValue != null) {
@@ -288,6 +289,17 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
         if (defaultValue != null) {
             if (defaultValue.getClass() != type) {
                 throw new IllegalArgumentException("The default value type cannot be cast to the type");
+            }
+        }
+    }
+
+    private void checkCanIndex(boolean indexed) {
+        if (indexed) {
+            if (!store.graphStore.configuration.isEnableIndexNodes() && isNodeTable()) {
+                throw new IllegalArgumentException("Can't use reverse index as node indexing is disabled (from Configuration)");
+            }
+            if (!store.graphStore.configuration.isEnableIndexEdges() && isEdgeTable()) {
+                throw new IllegalArgumentException("Can't index edge table as edge indexing is disabled (from Configuration)");
             }
         }
     }

--- a/src/main/java/org/gephi/graph/impl/TableImpl.java
+++ b/src/main/java/org/gephi/graph/impl/TableImpl.java
@@ -33,6 +33,8 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
 
     // Store
     protected final ColumnStore<T> store;
+    // Configuration
+    protected final ConfigurationImpl configuration;
 
     public TableImpl(Class<T> elementType) {
         this(null, elementType);
@@ -40,6 +42,12 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
 
     public TableImpl(GraphStore graphStore, Class<T> elementType) {
         store = new ColumnStore<>(graphStore, elementType);
+        if (graphStore == null) {
+            // Used for testing only
+            configuration = new ConfigurationImpl();
+        } else {
+            configuration = graphStore.configuration;
+        }
     }
 
     @Override
@@ -294,7 +302,7 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
     }
 
     private void checkCanIndex(boolean indexed) {
-        if (indexed) {
+        if (indexed && store.graphStore != null) {
             if (!store.graphStore.configuration.isEnableIndexNodes() && isNodeTable()) {
                 throw new IllegalArgumentException("Can't use reverse index as node indexing is disabled (from Configuration)");
             }

--- a/src/main/java/org/gephi/graph/impl/TableImpl.java
+++ b/src/main/java/org/gephi/graph/impl/TableImpl.java
@@ -304,10 +304,12 @@ public class TableImpl<T extends Element> implements Collection<Column>, Table {
     private void checkCanIndex(boolean indexed) {
         if (indexed && store.graphStore != null) {
             if (!store.graphStore.configuration.isEnableIndexNodes() && isNodeTable()) {
-                throw new IllegalArgumentException("Can't use reverse index as node indexing is disabled (from Configuration)");
+                throw new IllegalArgumentException(
+                        "Can't use reverse index as node indexing is disabled (from Configuration)");
             }
             if (!store.graphStore.configuration.isEnableIndexEdges() && isEdgeTable()) {
-                throw new IllegalArgumentException("Can't index edge table as edge indexing is disabled (from Configuration)");
+                throw new IllegalArgumentException(
+                        "Can't index edge table as edge indexing is disabled (from Configuration)");
             }
         }
     }

--- a/src/main/java/org/gephi/graph/impl/TimeStore.java
+++ b/src/main/java/org/gephi/graph/impl/TimeStore.java
@@ -26,12 +26,12 @@ public class TimeStore {
     // Lock (optional)
     protected final TableLockImpl lock;
     // Store
-    protected TimeIndexStore nodeIndexStore;
-    protected TimeIndexStore edgeIndexStore;
+    protected final TimeIndexStore nodeIndexStore;
+    protected final TimeIndexStore edgeIndexStore;
 
     public TimeStore(GraphStore store, boolean indexed) {
         this.graphStore = store;
-        this.lock = GraphStoreConfiguration.ENABLE_AUTO_LOCKING ? new TableLockImpl() : null;
+        this.lock = store.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
 
         TimeRepresentation timeRepresentation = GraphStoreConfiguration.DEFAULT_TIME_REPRESENTATION;
         if (store != null) {
@@ -43,18 +43,6 @@ public class TimeStore {
         } else {
             nodeIndexStore = new TimestampIndexStore<>(Node.class, lock, indexed);
             edgeIndexStore = new TimestampIndexStore<>(Edge.class, lock, indexed);
-        }
-    }
-
-    protected void resetConfiguration() {
-        if (graphStore != null) {
-            if (graphStore.configuration.getTimeRepresentation().equals(TimeRepresentation.INTERVAL)) {
-                nodeIndexStore = new IntervalIndexStore<>(Node.class, lock, nodeIndexStore.hasIndex());
-                edgeIndexStore = new IntervalIndexStore<>(Edge.class, lock, edgeIndexStore.hasIndex());
-            } else {
-                nodeIndexStore = new TimestampIndexStore<>(Node.class, lock, nodeIndexStore.hasIndex());
-                edgeIndexStore = new TimestampIndexStore<>(Edge.class, lock, edgeIndexStore.hasIndex());
-            }
         }
     }
 

--- a/src/main/java/org/gephi/graph/impl/TimeStore.java
+++ b/src/main/java/org/gephi/graph/impl/TimeStore.java
@@ -31,7 +31,7 @@ public class TimeStore {
 
     public TimeStore(GraphStore store, boolean indexed) {
         this.graphStore = store;
-        this.lock = store.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
+        this.lock = store != null && store.configuration.isEnableAutoLocking() ? new TableLockImpl() : null;
 
         TimeRepresentation timeRepresentation = GraphStoreConfiguration.DEFAULT_TIME_REPRESENTATION;
         if (store != null) {

--- a/src/test/java/org/gephi/graph/impl/AttributeUtilsTest.java
+++ b/src/test/java/org/gephi/graph/impl/AttributeUtilsTest.java
@@ -843,8 +843,8 @@ public class AttributeUtilsTest {
 
     @Test
     public void testIsNodeColumn() {
-        TableImpl tableNode = new TableImpl(Node.class, false);
-        TableImpl tableEdge = new TableImpl(Edge.class, false);
+        TableImpl tableNode = new TableImpl(Node.class);
+        TableImpl tableEdge = new TableImpl(Edge.class);
         Column column = tableNode.addColumn("0", Integer.class);
 
         Assert.assertTrue(AttributeUtils.isNodeColumn(column));
@@ -853,8 +853,8 @@ public class AttributeUtilsTest {
 
     @Test
     public void testIsEdgeColumn() {
-        TableImpl tableNode = new TableImpl(Node.class, false);
-        TableImpl tableEdge = new TableImpl(Edge.class, false);
+        TableImpl tableNode = new TableImpl(Node.class);
+        TableImpl tableEdge = new TableImpl(Edge.class);
         Column column = tableEdge.addColumn("0", Integer.class);
 
         Assert.assertTrue(AttributeUtils.isEdgeColumn(column));

--- a/src/test/java/org/gephi/graph/impl/ColumnNoIndexTest.java
+++ b/src/test/java/org/gephi/graph/impl/ColumnNoIndexTest.java
@@ -244,10 +244,10 @@ public class ColumnNoIndexTest {
     private GraphStore generateGraphStoreWithColumns() {
         GraphStore graphStore = new GraphStore();
         ColumnStore<Node> columnStore = graphStore.nodeTable.store;
-        columnStore.addColumn(new ColumnImpl("foo", String.class, "foo", null, Origin.DATA, false, false));
-        columnStore.addColumn(new ColumnImpl("age", Integer.class, "Age", null, Origin.DATA, true, false));
+        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "foo", String.class, "foo", null, Origin.DATA, false, false));
+        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "age", Integer.class, "Age", null, Origin.DATA, true, false));
         columnStore
-                .addColumn(new ColumnImpl("price", TimestampIntegerMap.class, "Price", null, Origin.DATA, true, false));
+                .addColumn(new ColumnImpl(graphStore.nodeTable, "price", TimestampIntegerMap.class, "Price", null, Origin.DATA, true, false));
 
         return graphStore;
     }

--- a/src/test/java/org/gephi/graph/impl/ColumnNoIndexTest.java
+++ b/src/test/java/org/gephi/graph/impl/ColumnNoIndexTest.java
@@ -244,10 +244,12 @@ public class ColumnNoIndexTest {
     private GraphStore generateGraphStoreWithColumns() {
         GraphStore graphStore = new GraphStore();
         ColumnStore<Node> columnStore = graphStore.nodeTable.store;
-        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "foo", String.class, "foo", null, Origin.DATA, false, false));
-        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "age", Integer.class, "Age", null, Origin.DATA, true, false));
-        columnStore
-                .addColumn(new ColumnImpl(graphStore.nodeTable, "price", TimestampIntegerMap.class, "Price", null, Origin.DATA, true, false));
+        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "foo", String.class, "foo", null, Origin.DATA, false,
+                false));
+        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "age", Integer.class, "Age", null, Origin.DATA, true,
+                false));
+        columnStore.addColumn(new ColumnImpl(graphStore.nodeTable, "price", TimestampIntegerMap.class, "Price", null,
+                Origin.DATA, true, false));
 
         return graphStore;
     }

--- a/src/test/java/org/gephi/graph/impl/ColumnObserverTest.java
+++ b/src/test/java/org/gephi/graph/impl/ColumnObserverTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import org.gephi.graph.api.Column;
 import org.gephi.graph.api.ColumnDiff;
 import org.gephi.graph.api.ColumnObserver;
+import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Element;
 import org.gephi.graph.api.types.TimestampIntegerMap;
@@ -43,6 +44,15 @@ public class ColumnObserverTest {
         Assert.assertSame(observer.getColumn(), column);
         Assert.assertFalse(observer.isDestroyed());
         Assert.assertFalse(observer.hasColumnChanged());
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testCreateObserverWhenDisabled() {
+        GraphStore store = new GraphStore(null, Configuration.builder().enableObservers(false).build());
+        TableImpl table = store.nodeTable;
+        Column column = table.addColumn("0", Integer.class);
+
+        column.createColumnObserver(false);
     }
 
     @Test(expectedExceptions = RuntimeException.class)
@@ -255,7 +265,8 @@ public class ColumnObserverTest {
 
     @Test
     public void testDestroyObserver() {
-        TableImpl table = new TableImpl(Node.class, false);
+        GraphStore store = new GraphStore();
+        TableImpl table = store.nodeTable;
         Column column = table.addColumn("0", Integer.class);
 
         ColumnObserver observer = column.createColumnObserver(false);

--- a/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
+++ b/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
@@ -267,4 +267,9 @@ public class ConfigurationTest {
         Configuration c2 = new ConfigurationImpl(c1).toConfiguration();
         Assert.assertEquals(c1, c2);
     }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testExceptionSpatialIndexWithDisabledNodeProperties() {
+        Configuration.builder().enableSpatialIndex(true).enableNodeProperties(false).build();
+    }
 }

--- a/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
+++ b/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
@@ -136,6 +136,18 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void testDisableAutoLocking() {
+        Configuration c = Configuration.builder().enableAutoLocking(false).build();
+        Assert.assertEquals(c.isEnableAutoLocking(), Boolean.FALSE);
+    }
+
+    @Test
+    public void testDisableTimeIndexing() {
+        Configuration c = Configuration.builder().enableIndexTime(false).build();
+        Assert.assertEquals(c.isEnableIndexTime(), Boolean.FALSE);
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     public void testSetEdgeWeightColumnDeprecated() {
         Configuration c = new Configuration();

--- a/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
+++ b/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
@@ -25,7 +25,24 @@ import org.testng.annotations.Test;
 public class ConfigurationTest {
 
     @Test
-    public void testDefault() {
+    public void testDefaultBuilder() {
+        Configuration c = Configuration.builder().build();
+        Assert.assertNotNull(c);
+        Assert.assertNotNull(c.getNodeIdType());
+        Assert.assertEquals(c, Configuration.builder().build());
+        Assert.assertEquals(c.hashCode(), Configuration.builder().build().hashCode());
+    }
+
+    @Test
+    public void testBuilderMultipleSet() {
+        Configuration.Builder b = Configuration.builder();
+        Assert.assertEquals(b.build().getNodeIdType(), String.class);
+        b.nodeIdType(Integer.class);
+        Assert.assertEquals(b.build().getNodeIdType(), Integer.class);
+    }
+
+    @Test
+    public void testDefaultDeprecated() {
         Configuration c = new Configuration();
         Assert.assertNotNull(c.getNodeIdType());
         Assert.assertNotNull(c.getEdgeIdType());
@@ -35,6 +52,12 @@ public class ConfigurationTest {
 
     @Test
     public void testSetNodeIdType() {
+        Configuration c = Configuration.builder().nodeIdType(Float.class).build();
+        Assert.assertEquals(c.getNodeIdType(), Float.class);
+    }
+
+    @Test
+    public void testSetNodeIdTypeDeprecated() {
         Configuration c = new Configuration();
         c.setNodeIdType(Float.class);
         Assert.assertEquals(c.getNodeIdType(), Float.class);
@@ -42,6 +65,12 @@ public class ConfigurationTest {
 
     @Test
     public void testSetEdgeIdType() {
+        Configuration c = Configuration.builder().edgeIdType(Float.class).build();
+        Assert.assertEquals(c.getEdgeIdType(), Float.class);
+    }
+
+    @Test
+    public void testSetEdgeIdTypeDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeIdType(Float.class);
         Assert.assertEquals(c.getEdgeIdType(), Float.class);
@@ -49,6 +78,12 @@ public class ConfigurationTest {
 
     @Test
     public void testSetEdgeLabelType() {
+        Configuration c = Configuration.builder().edgeLabelType(Float.class).build();
+        Assert.assertEquals(c.getEdgeLabelType(), Float.class);
+    }
+
+    @Test
+    public void testSetEdgeLabelTypeDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeLabelType(Float.class);
         Assert.assertEquals(c.getEdgeLabelType(), Float.class);
@@ -56,6 +91,16 @@ public class ConfigurationTest {
 
     @Test
     public void testSetEdgeWeightType() {
+        Configuration c = Configuration.builder().edgeWeightType(IntervalDoubleMap.class).build();
+        Assert.assertEquals(c.getEdgeWeightType(), IntervalDoubleMap.class);
+        c = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
+        Assert.assertEquals(c.getEdgeWeightType(), TimestampDoubleMap.class);
+        c = Configuration.builder().edgeWeightType(Double.class).build();
+        Assert.assertEquals(c.getEdgeWeightType(), Double.class);
+    }
+
+    @Test
+    public void testSetEdgeWeightTypeDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightType(IntervalDoubleMap.class);
         Assert.assertEquals(c.getEdgeWeightType(), IntervalDoubleMap.class);
@@ -67,6 +112,12 @@ public class ConfigurationTest {
 
     @Test
     public void testSetTimeRepresentation() {
+        Configuration c = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
+        Assert.assertEquals(c.getTimeRepresentation(), TimeRepresentation.INTERVAL);
+    }
+
+    @Test
+    public void testSetTimeRepresentationDeprecated() {
         Configuration c = new Configuration();
         c.setTimeRepresentation(TimeRepresentation.INTERVAL);
         Assert.assertEquals(c.getTimeRepresentation(), TimeRepresentation.INTERVAL);
@@ -74,6 +125,12 @@ public class ConfigurationTest {
 
     @Test
     public void testSetEdgeWeightColumn() {
+        Configuration c = Configuration.builder().edgeWeightColumn(false).build();
+        Assert.assertEquals(c.getEdgeWeightColumn(), Boolean.FALSE);
+    }
+
+    @Test
+    public void testSetEdgeWeightColumnDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightColumn(Boolean.FALSE);
         Assert.assertEquals(c.getEdgeWeightColumn(), Boolean.FALSE);
@@ -81,61 +138,118 @@ public class ConfigurationTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetNodeIdTypeUnsupported() {
+        Configuration.builder().nodeIdType(int[].class).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSetNodeIdTypeUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setNodeIdType(int[].class);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetEdgeIdTypeUnsupported() {
+        Configuration.builder().edgeIdType(int[].class).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSetEdgeIdTypeUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeIdType(int[].class);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetEdgeWeightTypeFloatUnsupported() {
+        Configuration.builder().edgeWeightType(Float.class).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSetEdgeWeightTypeFloatUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightType(Float.class);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetEdgeWeightTypeNotNumberUnsupported() {
+        Configuration.builder().edgeWeightType(String.class).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSetEdgeWeightTypeNotNumberUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightType(String.class);
     }
 
     @Test
-    public void testDefaultEquals() {
-        Assert.assertTrue(new Configuration().equals(new Configuration()));
+    public void testDefaultEqualsDeprecated() {
+        Assert.assertEquals(new Configuration(), new Configuration());
     }
 
     @Test
-    public void testDefaultHashCode() {
+    public void testDefaultHashCodeDeprecated() {
         Assert.assertEquals(new Configuration().hashCode(), new Configuration().hashCode());
     }
 
     @Test
     public void testEquals() {
+        Configuration c1 = Configuration.builder().nodeIdType(Float.class).build();
+        Configuration c2 = Configuration.builder().build();
+        Assert.assertNotEquals(c2, c1);
+    }
+
+    @Test
+    public void testEqualsDeprecated() {
         Configuration c1 = new Configuration();
         Configuration c2 = new Configuration();
+        Assert.assertEquals(c2, c1);
         c2.setNodeIdType(Float.class);
-        Assert.assertFalse(c1.equals(c2));
+        Assert.assertNotEquals(c2, c1);
     }
 
     @Test
     public void testHashCode() {
+        Configuration c1 = Configuration.builder().nodeIdType(Float.class).build();
+        Configuration c2 = Configuration.builder().build();
+        Assert.assertNotEquals(c2.hashCode(), c1.hashCode());
+    }
+
+    @Test
+    public void testHashCodeDeprecated() {
         Configuration c1 = new Configuration();
         Configuration c2 = new Configuration();
+        Assert.assertEquals(c1.hashCode(), c2.hashCode());
         c2.setNodeIdType(Float.class);
         Assert.assertNotEquals(c1.hashCode(), c2.hashCode());
     }
 
     @Test
     public void testCopy() {
+        Configuration c1 = Configuration.builder().build();
+        Configuration c2 = c1.copy();
+        Assert.assertEquals(c2, c1);
+        Assert.assertNotSame(c2, c1);
+
+        Configuration c3 = Configuration.builder().nodeIdType(Float.class).build();
+        Assert.assertNotEquals(c3, c1);
+        Configuration c4 = c3.copy();
+        Assert.assertEquals(c4, c3);
+        Assert.assertEquals(Float.class, c4.getNodeIdType());
+    }
+
+    @Test
+    public void testCopyDeprecated() {
         Configuration c1 = new Configuration();
         Configuration c2 = c1.copy();
-        Assert.assertTrue(c1.equals(c2));
+        Assert.assertEquals(c2, c1);
         c1.setNodeIdType(Float.class);
         Assert.assertNotEquals(c2.getNodeIdType(), Float.class);
-        Assert.assertFalse(c1.equals(c2));
+        Assert.assertNotEquals(c2, c1);
+    }
+
+    @Test
+    public void testToConfiguration() {
+        Configuration c1 = Configuration.builder().nodeIdType(Float.class).build();
+        Configuration c2 = new ConfigurationImpl(c1).toConfiguration();
+        Assert.assertEquals(c1, c2);
     }
 }

--- a/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
+++ b/src/test/java/org/gephi/graph/impl/ConfigurationTest.java
@@ -42,6 +42,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testDefaultDeprecated() {
         Configuration c = new Configuration();
         Assert.assertNotNull(c.getNodeIdType());
@@ -57,6 +58,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testSetNodeIdTypeDeprecated() {
         Configuration c = new Configuration();
         c.setNodeIdType(Float.class);
@@ -70,6 +72,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testSetEdgeIdTypeDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeIdType(Float.class);
@@ -83,6 +86,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testSetEdgeLabelTypeDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeLabelType(Float.class);
@@ -100,6 +104,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testSetEdgeWeightTypeDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightType(IntervalDoubleMap.class);
@@ -117,6 +122,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testSetTimeRepresentationDeprecated() {
         Configuration c = new Configuration();
         c.setTimeRepresentation(TimeRepresentation.INTERVAL);
@@ -130,6 +136,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testSetEdgeWeightColumnDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightColumn(Boolean.FALSE);
@@ -153,6 +160,7 @@ public class ConfigurationTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    @SuppressWarnings("deprecation")
     public void testSetEdgeIdTypeUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeIdType(int[].class);
@@ -164,6 +172,7 @@ public class ConfigurationTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    @SuppressWarnings("deprecation")
     public void testSetEdgeWeightTypeFloatUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightType(Float.class);
@@ -175,17 +184,20 @@ public class ConfigurationTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    @SuppressWarnings("deprecation")
     public void testSetEdgeWeightTypeNotNumberUnsupportedDeprecated() {
         Configuration c = new Configuration();
         c.setEdgeWeightType(String.class);
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testDefaultEqualsDeprecated() {
         Assert.assertEquals(new Configuration(), new Configuration());
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testDefaultHashCodeDeprecated() {
         Assert.assertEquals(new Configuration().hashCode(), new Configuration().hashCode());
     }
@@ -198,6 +210,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testEqualsDeprecated() {
         Configuration c1 = new Configuration();
         Configuration c2 = new Configuration();
@@ -214,6 +227,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testHashCodeDeprecated() {
         Configuration c1 = new Configuration();
         Configuration c2 = new Configuration();
@@ -237,6 +251,7 @@ public class ConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testCopyDeprecated() {
         Configuration c1 = new Configuration();
         Configuration c2 = c1.copy();

--- a/src/test/java/org/gephi/graph/impl/EdgeImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeImplTest.java
@@ -54,8 +54,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetDefaultTimestampWeight() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(42.0, 1.0);
@@ -64,8 +63,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetDefaultTimestampWeightWhenNotSet() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Assert.assertEquals(e.getWeight(2.0), GraphStoreConfiguration.DEFAULT_DYNAMIC_EDGE_WEIGHT_WHEN_MISSING);
@@ -73,9 +71,8 @@ public class EdgeImplTest {
 
     @Test
     public void testGetDefaultIntervalWeight() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(42.0, new Interval(1.0, 2.0));
@@ -85,9 +82,8 @@ public class EdgeImplTest {
 
     @Test
     public void testGetDefaultIntervalWeightWhenNotSet() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Assert.assertEquals(e
@@ -96,9 +92,8 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightInterval() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(42.0, new Interval(1.0, 2.0));
@@ -107,9 +102,8 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightIntervalMax() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
 
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Column col = graphStore.edgeTable.store.getColumnByIndex(GraphStoreConfiguration.EDGE_WEIGHT_INDEX);
@@ -123,8 +117,7 @@ public class EdgeImplTest {
 
     @Test
     public void testSetTimestampWeight() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(42.0, 1.0);
@@ -136,9 +129,8 @@ public class EdgeImplTest {
 
     @Test
     public void testSetIntervalWeight() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(IntervalDoubleMap.class);
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Interval i1 = new Interval(1.0, 2.0);
@@ -152,9 +144,8 @@ public class EdgeImplTest {
 
     @Test
     public void testIntervalWeightUsesFirstValueInOverlappingIntervalsEstimator() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(42.0, new Interval(1.0, 2.0));
@@ -177,8 +168,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightStaticError() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(1.0, 1.0);
@@ -199,8 +189,7 @@ public class EdgeImplTest {
 
     @Test
     public void testHasDynamicWeightTimestamp() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Assert.assertTrue(e.hasDynamicWeight());
@@ -210,9 +199,8 @@ public class EdgeImplTest {
 
     @Test
     public void testHasDynamicWeightInterval() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(IntervalDoubleMap.class);
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Assert.assertTrue(e.hasDynamicWeight());
@@ -222,8 +210,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetDefaultWeightByGraphView() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Assert.assertEquals(e
@@ -232,8 +219,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetTimestampWeightMainGraphView() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(42.0, 1.0);
@@ -244,9 +230,8 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightGraphViewMax() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
 
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Column col = graphStore.edgeTable.store.getColumnByIndex(GraphStoreConfiguration.EDGE_WEIGHT_INDEX);
@@ -262,8 +247,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightNoValue() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setAttribute("weight", null);
@@ -273,8 +257,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightDefaultEstimator() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(10.0, 1.0);
@@ -284,8 +267,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightAverageEstimator() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Column col = graphStore.edgeTable.store.getColumnByIndex(GraphStoreConfiguration.EDGE_WEIGHT_INDEX);
@@ -297,8 +279,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightWithView() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(10.0, 1.0);
@@ -312,8 +293,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightWithViewStatic() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(Double.class);
+        Configuration config = Configuration.builder().edgeWeightType(Double.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(10.0);
@@ -324,8 +304,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightsTimestamp() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(10.0, 3.0);
@@ -346,9 +325,8 @@ public class EdgeImplTest {
 
     @Test
     public void testGetWeightsInterval() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(IntervalDoubleMap.class);
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         e.setWeight(10.0, new Interval(3.0, 4.0));
@@ -377,8 +355,7 @@ public class EdgeImplTest {
 
     @Test
     public void testSetAttributeWeightTimestamp() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore graphStore = GraphGenerator.generateTinyGraphStore(config);
         Edge e = graphStore.getEdge("0");
         Column col = graphStore.edgeTable.getColumn(GraphStoreConfiguration.EDGE_WEIGHT_INDEX);

--- a/src/test/java/org/gephi/graph/impl/EdgeImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeImplTest.java
@@ -402,7 +402,7 @@ public class EdgeImplTest {
 
     @Test
     public void testGetTypeLabelCustom() {
-        GraphStore graphStore = new GraphStore(null);
+        GraphStore graphStore = new GraphStore();
         EdgeTypeStore edgeTypeStore = graphStore.edgeTypeStore;
         int typeId = edgeTypeStore.addType("foo");
 

--- a/src/test/java/org/gephi/graph/impl/EdgeImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeImplTest.java
@@ -426,4 +426,21 @@ public class EdgeImplTest {
             Assert.assertSame(e.getTable(), graphStore.getModel().getEdgeTable());
         }
     }
+
+    @Test
+    public void testProperties() {
+        GraphStore graphStore = GraphGenerator.generateTinyGraphStore();
+        Edge e = graphStore.getEdge("0");
+        Assert.assertNotNull(e.getTextProperties());
+        Assert.assertNotNull(e.getColor());
+        Assert.assertEquals(e.alpha(), 1f);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testPropertiesDisabled() {
+        GraphStore graphStore = GraphGenerator
+                .generateTinyGraphStore(Configuration.builder().enableEdgeProperties(false).build());
+        Edge e = graphStore.getEdge("0");
+        Assert.assertNull(e.getColor());
+    }
 }

--- a/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
@@ -1926,7 +1926,7 @@ public class EdgeStoreTest {
     @Test
     public void testReturnFalseWithoutParallelEdges() {
         ConfigurationImpl configuration = new ConfigurationImpl(
-            Configuration.builder().enableParallelEdgesSameType(false).build());
+                Configuration.builder().enableParallelEdgesSameType(false).build());
         EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, configuration, null, null, null);
         EdgeImpl edge = GraphGenerator.generateSingleEdge(1);
         EdgeImpl edge2 = new EdgeImpl('0', edge.graphStore, edge.source, edge.target, 2, 1.0, true);

--- a/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
@@ -1911,6 +1911,23 @@ public class EdgeStoreTest {
         Assert.assertEquals(1, edgeStore.size(1));
     }
 
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testAddWithoutAutoRegistration() {
+        ConfigurationImpl config = new ConfigurationImpl(Configuration.builder().enableAutoEdgeTypeRegistration(false).build());
+        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(config), null, config, null, null, null);
+        EdgeImpl edge = GraphGenerator.generateSingleEdge(4);
+        edgeStore.add(edge);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testSetTypeWithoutAutoRegistration() {
+        ConfigurationImpl config = new ConfigurationImpl(Configuration.builder().enableAutoEdgeTypeRegistration(false).build());
+        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(config), null, config, null, null, null);
+        EdgeImpl edge = GraphGenerator.generateSingleEdge();
+        edgeStore.add(edge);
+        edgeStore.setEdgeType(edge, 1);
+    }
+
     @Test
     public void testSetTypeWithMutualEdge() {
         EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, null, null, null, null);

--- a/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.Edge;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -1302,7 +1303,7 @@ public class EdgeStoreTest {
     public void testRemoveMutualEdge() {
         EdgeImpl[] edges = GraphGenerator.generateMutualEdges(1);
         EdgeTypeStore edgeTypeStore = new EdgeTypeStore();
-        EdgeStore edgeStore = new EdgeStore(edgeTypeStore, null, null, null, null);
+        EdgeStore edgeStore = new EdgeStore(edgeTypeStore, null, null, null, null, null);
         edgeStore.addAll(Arrays.asList(edges));
         edgeStore.remove(edges[0]);
         Assert.assertFalse(edges[0].isMutual());
@@ -1652,7 +1653,7 @@ public class EdgeStoreTest {
     @Test
     public void testTypeCounting() {
         EdgeTypeStore edgeTypeStore = new EdgeTypeStore();
-        EdgeStore edgeStore = new EdgeStore(edgeTypeStore, null, null, null, null);
+        EdgeStore edgeStore = new EdgeStore(edgeTypeStore, null, null, null, null, null);
         EdgeImpl[] edges = GraphGenerator.generateSmallMultiTypeEdgeList();
 
         Int2IntMap counts = new Int2IntOpenHashMap();
@@ -1898,7 +1899,7 @@ public class EdgeStoreTest {
 
     @Test
     public void testSetType() {
-        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, null, null, null);
+        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, null, null, null, null);
         EdgeImpl edge = GraphGenerator.generateSingleEdge(4);
         edgeStore.add(edge);
         edgeStore.setEdgeType(edge, 1);
@@ -1912,7 +1913,7 @@ public class EdgeStoreTest {
 
     @Test
     public void testSetTypeWithMutualEdge() {
-        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, null, null, null);
+        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, null, null, null, null);
         EdgeImpl[] edges = GraphGenerator.generateMutualEdges(4);
         edgeStore.addAll(Arrays.asList(edges));
         Assert.assertTrue(edges[0].isMutual());
@@ -1922,10 +1923,11 @@ public class EdgeStoreTest {
         Assert.assertFalse(edges[1].isMutual());
     }
 
-    // Can only run when GraphStoreConfiguration.ENABLE_PARALLEL_EDGES = false
-    @Test(enabled = false)
+    @Test
     public void testReturnFalseWithoutParallelEdges() {
-        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, null, null, null);
+        ConfigurationImpl configuration = new ConfigurationImpl(
+            Configuration.builder().enableParallelEdgesSameType(false).build());
+        EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(), null, configuration, null, null, null);
         EdgeImpl edge = GraphGenerator.generateSingleEdge(1);
         EdgeImpl edge2 = new EdgeImpl('0', edge.graphStore, edge.source, edge.target, 2, 1.0, true);
         Assert.assertTrue(edgeStore.add(edge));

--- a/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeStoreTest.java
@@ -1913,7 +1913,8 @@ public class EdgeStoreTest {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testAddWithoutAutoRegistration() {
-        ConfigurationImpl config = new ConfigurationImpl(Configuration.builder().enableAutoEdgeTypeRegistration(false).build());
+        ConfigurationImpl config = new ConfigurationImpl(
+                Configuration.builder().enableAutoEdgeTypeRegistration(false).build());
         EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(config), null, config, null, null, null);
         EdgeImpl edge = GraphGenerator.generateSingleEdge(4);
         edgeStore.add(edge);
@@ -1921,7 +1922,8 @@ public class EdgeStoreTest {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testSetTypeWithoutAutoRegistration() {
-        ConfigurationImpl config = new ConfigurationImpl(Configuration.builder().enableAutoEdgeTypeRegistration(false).build());
+        ConfigurationImpl config = new ConfigurationImpl(
+                Configuration.builder().enableAutoEdgeTypeRegistration(false).build());
         EdgeStore edgeStore = new EdgeStore(new EdgeTypeStore(config), null, config, null, null, null);
         EdgeImpl edge = GraphGenerator.generateSingleEdge();
         edgeStore.add(edge);

--- a/src/test/java/org/gephi/graph/impl/EdgeTypeStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeTypeStoreTest.java
@@ -15,6 +15,7 @@
  */
 package org.gephi.graph.impl;
 
+import org.gephi.graph.api.Configuration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -283,8 +284,9 @@ public class EdgeTypeStoreTest {
 
     @Test
     public void testAddDifferentType() {
-        EdgeTypeStore edgeTypeStore = new EdgeTypeStore();
-        edgeTypeStore.configuration.setEdgeLabelType(Integer.class);
+        EdgeTypeStore edgeTypeStore = new EdgeTypeStore(
+            new ConfigurationImpl(Configuration.builder().edgeLabelType(Integer.class).build())
+        );
         int id = edgeTypeStore.addType(42);
         Assert.assertEquals(id, 1);
         Assert.assertEquals(edgeTypeStore.getLabel(1), 42);

--- a/src/test/java/org/gephi/graph/impl/EdgeTypeStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/EdgeTypeStoreTest.java
@@ -285,8 +285,7 @@ public class EdgeTypeStoreTest {
     @Test
     public void testAddDifferentType() {
         EdgeTypeStore edgeTypeStore = new EdgeTypeStore(
-            new ConfigurationImpl(Configuration.builder().edgeLabelType(Integer.class).build())
-        );
+                new ConfigurationImpl(Configuration.builder().edgeLabelType(Integer.class).build()));
         int id = edgeTypeStore.addType(42);
         Assert.assertEquals(id, 1);
         Assert.assertEquals(edgeTypeStore.getLabel(1), 42);

--- a/src/test/java/org/gephi/graph/impl/ElementImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/ElementImplTest.java
@@ -106,9 +106,10 @@ public class ElementImplTest {
     @Test
     public void testSetAttributeStandardizedType() {
         GraphStore store = new GraphStore();
-        store.nodeTable.store
-                .addColumn(new ColumnImpl(store.nodeTable, "arr1", Integer[].class, "Array", null, Origin.DATA, true, false));
-        store.nodeTable.store.addColumn(new ColumnImpl(store.nodeTable, "arr2", int[].class, "Array", null, Origin.DATA, true, false));
+        store.nodeTable.store.addColumn(new ColumnImpl(store.nodeTable, "arr1", Integer[].class, "Array", null,
+                Origin.DATA, true, false));
+        store.nodeTable.store.addColumn(new ColumnImpl(store.nodeTable, "arr2", int[].class, "Array", null, Origin.DATA,
+                true, false));
         Column column1 = store.nodeTable.store.getColumn("arr1");
         Column column2 = store.nodeTable.store.getColumn("arr2");
 
@@ -588,7 +589,8 @@ public class ElementImplTest {
     public void testGetDefaultValue() {
         GraphStore store = new GraphStore();
         Integer defaultValue = 25;
-        Column column = new ColumnImpl(store.nodeTable,"age", Integer.class, "Age", defaultValue, Origin.DATA, true, false);
+        Column column = new ColumnImpl(store.nodeTable, "age", Integer.class, "Age", defaultValue, Origin.DATA, true,
+                false);
         store.nodeTable.store.addColumn(column);
 
         NodeImpl node = new NodeImpl("0", store);
@@ -1195,8 +1197,7 @@ public class ElementImplTest {
 
     // Utility
     private GraphStore getIntervalGraphStore() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphStore store = graphModel.store;
         return store;

--- a/src/test/java/org/gephi/graph/impl/ElementImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/ElementImplTest.java
@@ -107,8 +107,8 @@ public class ElementImplTest {
     public void testSetAttributeStandardizedType() {
         GraphStore store = new GraphStore();
         store.nodeTable.store
-                .addColumn(new ColumnImpl("arr1", Integer[].class, "Array", null, Origin.DATA, true, false));
-        store.nodeTable.store.addColumn(new ColumnImpl("arr2", int[].class, "Array", null, Origin.DATA, true, false));
+                .addColumn(new ColumnImpl(store.nodeTable, "arr1", Integer[].class, "Array", null, Origin.DATA, true, false));
+        store.nodeTable.store.addColumn(new ColumnImpl(store.nodeTable, "arr2", int[].class, "Array", null, Origin.DATA, true, false));
         Column column1 = store.nodeTable.store.getColumn("arr1");
         Column column2 = store.nodeTable.store.getColumn("arr2");
 
@@ -588,7 +588,7 @@ public class ElementImplTest {
     public void testGetDefaultValue() {
         GraphStore store = new GraphStore();
         Integer defaultValue = 25;
-        Column column = new ColumnImpl("age", Integer.class, "Age", defaultValue, Origin.DATA, true, false);
+        Column column = new ColumnImpl(store.nodeTable,"age", Integer.class, "Age", defaultValue, Origin.DATA, true, false);
         store.nodeTable.store.addColumn(column);
 
         NodeImpl node = new NodeImpl("0", store);

--- a/src/test/java/org/gephi/graph/impl/GraphBridgeTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphBridgeTest.java
@@ -44,7 +44,8 @@ public class GraphBridgeTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testVerifyConfigurationParallelEdges() {
-        Configuration destConfig = Configuration.builder().enableParallelEdgesSameType(!GraphStoreConfiguration.DEFAULT_ENABLE_PARALLEL_EDGES_SAME_TYPE).build();
+        Configuration destConfig = Configuration.builder()
+                .enableParallelEdgesSameType(!GraphStoreConfiguration.DEFAULT_ENABLE_PARALLEL_EDGES_SAME_TYPE).build();
         GraphModelImpl dest = new GraphModelImpl(destConfig);
 
         new GraphBridgeImpl(dest.store).copyNodes(GraphGenerator.generateTinyGraphStore().getNodes().toArray());
@@ -189,8 +190,7 @@ public class GraphBridgeTest {
 
     @Test
     public void testCopyEdgeWeightTimestamp() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(TimestampDoubleMap.class);
+        Configuration config = Configuration.builder().edgeWeightType(TimestampDoubleMap.class).build();
         GraphStore source = GraphGenerator.generateTinyGraphStore(config);
         EdgeImpl e0 = source.getEdge("0");
         e0.setWeight(42.0, 1.0);
@@ -207,9 +207,8 @@ public class GraphBridgeTest {
 
     @Test
     public void testCopyEdgeWeightInterval() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightType(IntervalDoubleMap.class);
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         GraphStore source = GraphGenerator.generateTinyGraphStore(config);
         EdgeImpl e0 = source.getEdge("0");
         e0.setWeight(42.0, new Interval(1.0, 2.0));
@@ -307,8 +306,7 @@ public class GraphBridgeTest {
         n1.setAttribute(c2, 10, new Interval(1.0, 2.0));
         n1.setAttribute(c2, 20, new Interval(3.0, 4.0));
 
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl model = new GraphModelImpl(config);
         GraphStore dest = model.store;
         new GraphBridgeImpl(dest).copyNodes(source.getNodes().toArray());
@@ -360,8 +358,7 @@ public class GraphBridgeTest {
         Node n1 = source.getNode("1");
         n1.addInterval(new Interval(1.0, 2.0));
 
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl model = new GraphModelImpl(config);
         GraphStore dest = model.store;
         new GraphBridgeImpl(dest).copyNodes(source.getNodes().toArray());

--- a/src/test/java/org/gephi/graph/impl/GraphBridgeTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphBridgeTest.java
@@ -36,8 +36,15 @@ public class GraphBridgeTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testVerifyConfiguration() {
-        Configuration destConfig = new Configuration();
-        destConfig.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration destConfig = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
+        GraphModelImpl dest = new GraphModelImpl(destConfig);
+
+        new GraphBridgeImpl(dest.store).copyNodes(GraphGenerator.generateTinyGraphStore().getNodes().toArray());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testVerifyConfigurationParallelEdges() {
+        Configuration destConfig = Configuration.builder().enableParallelEdgesSameType(!GraphStoreConfiguration.DEFAULT_ENABLE_PARALLEL_EDGES_SAME_TYPE).build();
         GraphModelImpl dest = new GraphModelImpl(destConfig);
 
         new GraphBridgeImpl(dest.store).copyNodes(GraphGenerator.generateTinyGraphStore().getNodes().toArray());

--- a/src/test/java/org/gephi/graph/impl/GraphFactoryTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphFactoryTest.java
@@ -132,8 +132,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testIntegerNodeId() {
-        Configuration config = new Configuration();
-        config.setNodeIdType(Integer.class);
+        Configuration config = Configuration.builder().nodeIdType(Integer.class).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         Node node = graphFactory.newNode();
@@ -142,8 +141,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testIntegerEdgeId() {
-        Configuration config = new Configuration();
-        config.setEdgeIdType(Integer.class);
+        Configuration config = Configuration.builder().edgeIdType(Integer.class).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
 
@@ -156,8 +154,7 @@ public class GraphFactoryTest {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnsupportedNodeId() {
-        Configuration config = new Configuration();
-        config.setNodeIdType(Float.class);
+        Configuration config = Configuration.builder().nodeIdType(Float.class).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         graphFactory.newNode();
@@ -165,8 +162,7 @@ public class GraphFactoryTest {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnsupportedEdgeId() {
-        Configuration config = new Configuration();
-        config.setEdgeIdType(Float.class);
+        Configuration config = Configuration.builder().edgeIdType(Float.class).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
 
@@ -178,8 +174,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testAutoIncrementNodeInt() {
-        Configuration config = new Configuration();
-        config.setNodeIdType(Integer.class);
+        Configuration config = Configuration.builder().nodeIdType(Integer.class).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         graphFactory.newNode(10);
@@ -192,8 +187,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testAutoIncrementEdgeInt() {
-        Configuration config = new Configuration();
-        config.setEdgeIdType(Integer.class);
+        Configuration config = Configuration.builder().edgeIdType(Integer.class).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         Node n1 = graphFactory.newNode();
@@ -210,7 +204,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testAutoIncrementNodeString() {
-        GraphModelImpl graphModel = new GraphModelImpl(new Configuration());
+        GraphModelImpl graphModel = new GraphModelImpl();
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         graphFactory.newNode("10");
         Assert.assertEquals(graphFactory.newNode().getId(), "11");
@@ -224,7 +218,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testAutoIncrementNotInteger() {
-        GraphModelImpl graphModel = new GraphModelImpl(new Configuration());
+        GraphModelImpl graphModel = new GraphModelImpl();
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         graphFactory.newNode("3543543523242");
         Assert.assertEquals(graphFactory.newNode().getId(), "0");
@@ -232,7 +226,7 @@ public class GraphFactoryTest {
 
     @Test
     public void testAutoIncrementEdgeString() {
-        GraphModelImpl graphModel = new GraphModelImpl(new Configuration());
+        GraphModelImpl graphModel = new GraphModelImpl();
         GraphFactoryImpl graphFactory = new GraphFactoryImpl(graphModel.store);
         Node n1 = graphFactory.newNode();
         Node n2 = graphFactory.newNode();

--- a/src/test/java/org/gephi/graph/impl/GraphGenerator.java
+++ b/src/test/java/org/gephi/graph/impl/GraphGenerator.java
@@ -452,14 +452,18 @@ public class GraphGenerator {
         return generateTinyGraphStore(config);
     }
 
-    public static GraphStore generateTinyGraphStoreWithSelfLoop() {
-        GraphModelImpl graphModel = new GraphModelImpl(new Configuration());
+    public static GraphStore generateTinyGraphStoreWithSelfLoop(Configuration configuration) {
+        GraphModelImpl graphModel = new GraphModelImpl(configuration);
         GraphStore graphStore = graphModel.store;
         NodeImpl n1 = new NodeImpl("1", graphStore);
         EdgeImpl e = new EdgeImpl("0", graphStore, n1, n1, EdgeTypeStore.NULL_LABEL, 1.0, true);
         graphStore.addNode(n1);
         graphStore.addEdge(e);
         return graphStore;
+    }
+
+    public static GraphStore generateTinyGraphStoreWithSelfLoop() {
+        return generateTinyGraphStoreWithSelfLoop(Configuration.builder().build());
     }
 
     public static GraphStore generateTinyGraphStoreWithMutualEdge() {

--- a/src/test/java/org/gephi/graph/impl/GraphGenerator.java
+++ b/src/test/java/org/gephi/graph/impl/GraphGenerator.java
@@ -465,7 +465,7 @@ public class GraphGenerator {
     }
 
     public static GraphStore generateTinyGraphStoreWithMutualEdge() {
-        GraphModelImpl graphModel = new GraphModelImpl(new Configuration());
+        GraphModelImpl graphModel = new GraphModelImpl();
         GraphStore graphStore = graphModel.store;
         NodeImpl n1 = new NodeImpl("1", graphStore);
         NodeImpl n2 = new NodeImpl("2", graphStore);

--- a/src/test/java/org/gephi/graph/impl/GraphGenerator.java
+++ b/src/test/java/org/gephi/graph/impl/GraphGenerator.java
@@ -413,7 +413,7 @@ public class GraphGenerator {
     }
 
     public static GraphStore generateTinyUndirectedGraphStore() {
-        GraphModelImpl graphModel = new GraphModelImpl(new Configuration());
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().build());
         GraphStore graphStore = graphModel.store;
         Node n1 = graphStore.factory.newNode("1");
         Node n2 = graphStore.factory.newNode("2");
@@ -441,14 +441,12 @@ public class GraphGenerator {
     }
 
     public static GraphStore generateEmptyGraphStore(TimeRepresentation timeRepresentation) {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(timeRepresentation);
+        Configuration config = Configuration.builder().timeRepresentation(timeRepresentation).build();
         return generateEmptyGraphStore(config);
     }
 
     public static GraphStore generateTinyGraphStore(TimeRepresentation timeRepresentation) {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(timeRepresentation);
+        Configuration config = Configuration.builder().timeRepresentation(timeRepresentation).build();
         return generateTinyGraphStore(config);
     }
 

--- a/src/test/java/org/gephi/graph/impl/GraphModelTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphModelTest.java
@@ -344,6 +344,14 @@ public class GraphModelTest {
 
         Index index = graphModel.getNodeIndex();
         Assert.assertEquals(index.count(col, "bar"), 1);
+        Assert.assertSame(graphModel.getElementIndex(table), index);
+    }
+
+    @Test
+    public void testGetNodeIndexWithIndexConfigDisabled() {
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().enableIndexNodes(false).build());
+        Assert.assertNotNull(graphModel.getNodeIndex());
+        Assert.assertNotNull(graphModel.getNodeIndex().getColumnIndex(graphModel.defaultColumns().nodeId()));
     }
 
     @Test
@@ -360,6 +368,7 @@ public class GraphModelTest {
 
         Index index = graphModel.getNodeIndex(view);
         Assert.assertEquals(index.count(col, "bar"), 1);
+        Assert.assertSame(graphModel.getElementIndex(table, view), index);
     }
 
     @Test
@@ -376,6 +385,14 @@ public class GraphModelTest {
 
         Index index = graphModel.getEdgeIndex();
         Assert.assertEquals(index.count(col, "bar"), 1);
+        Assert.assertSame(graphModel.getElementIndex(table), index);
+    }
+
+    @Test
+    public void testGetEdgeIndexWithIndexConfigDisabled() {
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().enableIndexEdges(false).build());
+        Assert.assertNotNull(graphModel.getEdgeIndex());
+        Assert.assertNotNull(graphModel.getEdgeIndex().getColumnIndex(graphModel.defaultColumns().edgeId()));
     }
 
     @Test
@@ -395,6 +412,7 @@ public class GraphModelTest {
 
         Index index = graphModel.getEdgeIndex(view);
         Assert.assertEquals(index.count(col, "bar"), 1);
+        Assert.assertSame(graphModel.getElementIndex(table, view), index);
     }
 
     @Test
@@ -410,6 +428,12 @@ public class GraphModelTest {
     }
 
     @Test
+    public void testGetNodeTimeIndexWithIndexConfigDisabled() {
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().enableIndexTime(false).build());
+        Assert.assertNull(graphModel.getNodeTimeIndex());
+    }
+
+    @Test
     public void testGetEdgeTimestampIndex() {
         GraphModelImpl graphModel = new GraphModelImpl();
         Node n = graphModel.factory().newNode("1");
@@ -421,6 +445,12 @@ public class GraphModelTest {
         TimeIndex<Edge> index = graphModel.getEdgeTimeIndex();
         Assert.assertEquals(index.getMinTimestamp(), 1.0);
         Assert.assertEquals(index.getMaxTimestamp(), 1.0);
+    }
+
+    @Test
+    public void testGetEdgeTimeIndexWithIndexConfigDisabled() {
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().enableIndexTime(false).build());
+        Assert.assertNull(graphModel.getEdgeTimeIndex());
     }
 
     @Test

--- a/src/test/java/org/gephi/graph/impl/GraphModelTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphModelTest.java
@@ -548,7 +548,7 @@ public class GraphModelTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadEdgeWeightTypeConfigurationTimestamps() {
         Configuration config = Configuration.builder()
-            .timeRepresentation(TimeRepresentation.INTERVAL).edgeWeightType(IntervalDoubleMap.class).build();
+            .timeRepresentation(TimeRepresentation.TIMESTAMP).edgeWeightType(IntervalDoubleMap.class).build();
         new GraphModelImpl(config);
     }
 

--- a/src/test/java/org/gephi/graph/impl/GraphModelTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphModelTest.java
@@ -496,12 +496,10 @@ public class GraphModelTest {
 
     @Test
     public void testSetConfigurationIntervals() {
-        Configuration config = new Configuration();
+        Configuration config = Configuration.builder().nodeIdType(Integer.class)
+            .edgeIdType(Byte.class)
+            .timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
-        config.setNodeIdType(Integer.class);
-        config.setEdgeIdType(Byte.class);
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        graphModelImpl.setConfiguration(config);
         Assert.assertEquals(graphModelImpl.getConfiguration(), config);
         Assert.assertEquals(graphModelImpl.getNodeTable().getColumn("id").getTypeClass(), Integer.class);
         Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn("id").getTypeClass(), Byte.class);
@@ -516,20 +514,14 @@ public class GraphModelTest {
 
         Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn(GraphStoreConfiguration.EDGE_WEIGHT_INDEX)
                 .getTypeClass(), Double.class);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
-        graphModelImpl.setConfiguration(config);
-        Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn(GraphStoreConfiguration.EDGE_WEIGHT_INDEX)
-                .getTypeClass(), IntervalDoubleMap.class);
     }
 
     @Test
     public void testSetConfigurationTimestamps() {
-        Configuration config = new Configuration();
+        Configuration config = Configuration.builder().nodeIdType(Integer.class)
+            .edgeIdType(Byte.class)
+            .timeRepresentation(TimeRepresentation.TIMESTAMP).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
-        config.setNodeIdType(Integer.class);
-        config.setEdgeIdType(Byte.class);
-        config.setTimeRepresentation(TimeRepresentation.TIMESTAMP);
-        graphModelImpl.setConfiguration(config);
         Assert.assertEquals(graphModelImpl.getConfiguration(), config);
         Assert.assertEquals(graphModelImpl.getNodeTable().getColumn("id").getTypeClass(), Integer.class);
         Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn("id").getTypeClass(), Byte.class);
@@ -544,72 +536,34 @@ public class GraphModelTest {
 
         Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn(GraphStoreConfiguration.EDGE_WEIGHT_INDEX)
                 .getTypeClass(), Double.class);
-        config.setEdgeWeightType(TimestampDoubleMap.class);
-        graphModelImpl.setConfiguration(config);
-        Assert.assertEquals(graphModelImpl.getEdgeTable().getColumn(GraphStoreConfiguration.EDGE_WEIGHT_INDEX)
-                .getTypeClass(), TimestampDoubleMap.class);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadEdgeWeightTypeConfigurationIntervals() {
-        Configuration config = new Configuration();
-        GraphModelImpl graphModelImpl = new GraphModelImpl(config);
-        config.setEdgeWeightType(TimestampDoubleMap.class);
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
-        graphModelImpl.setConfiguration(config);
+        Configuration config = Configuration.builder()
+            .timeRepresentation(TimeRepresentation.INTERVAL).edgeWeightType(TimestampDoubleMap.class).build();
+        new GraphModelImpl(config);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadEdgeWeightTypeConfigurationTimestamps() {
-        Configuration config = new Configuration();
-        GraphModelImpl graphModelImpl = new GraphModelImpl(config);
-        config.setEdgeWeightType(IntervalDoubleMap.class);
-        config.setTimeRepresentation(TimeRepresentation.TIMESTAMP);
-        graphModelImpl.setConfiguration(config);
+        Configuration config = Configuration.builder()
+            .timeRepresentation(TimeRepresentation.INTERVAL).edgeWeightType(IntervalDoubleMap.class).build();
+        new GraphModelImpl(config);
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testSetConfigurationWithNodes() {
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testSetConfiguration() {
         GraphModelImpl graphModelImpl = new GraphModelImpl();
-        graphModelImpl.store.addNode(graphModelImpl.factory().newNode());
-        graphModelImpl.setConfiguration(new Configuration());
-    }
-
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testSetConfigurationWithGraphAttributes() {
-        GraphModelImpl graphModelImpl = new GraphModelImpl();
-        graphModelImpl.getGraph().setAttribute("foo", "bar");
-        graphModelImpl.setConfiguration(new Configuration());
-    }
-
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testSetConfigurationWithNodeColumns() {
-        GraphModelImpl graphModelImpl = new GraphModelImpl();
-        graphModelImpl.store.nodeTable.addColumn("foo", Integer.class);
-        graphModelImpl.setConfiguration(new Configuration());
-    }
-
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testSetConfigurationWithEdgeColumns() {
-        GraphModelImpl graphModelImpl = new GraphModelImpl();
-        graphModelImpl.store.edgeTable.addColumn("foo", Integer.class);
-        graphModelImpl.setConfiguration(new Configuration());
-    }
-
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testSetConfigurationWithEdgeType() {
-        GraphModelImpl graphModelImpl = new GraphModelImpl();
-        graphModelImpl.store.edgeTypeStore.addType("foo");
-        graphModelImpl.setConfiguration(new Configuration());
+        graphModelImpl.setConfiguration(Configuration.builder().build());
     }
 
     @Test
     public void testSetConfigurationEdgeWeightColumnFalse() {
-        GraphModelImpl graphModelImpl = new GraphModelImpl();
+        Configuration config = Configuration.builder()
+            .edgeWeightColumn(false).build();
+        GraphModelImpl graphModelImpl = new GraphModelImpl(config);
 
-        Configuration config = new Configuration();
-        config.setEdgeWeightColumn(Boolean.FALSE);
-        graphModelImpl.setConfiguration(config);
         Assert.assertFalse(graphModelImpl.store.edgeTable.hasColumn("weight"));
         Assert.assertNotEquals(graphModelImpl.store.edgeTable.addColumn("foo", Integer.class)
                 .getIndex(), GraphStoreConfiguration.EDGE_WEIGHT_INDEX);
@@ -617,38 +571,13 @@ public class GraphModelTest {
 
     @Test
     public void testSetConfigurationEdgeWeightColumnTrue() {
-        Configuration config = new Configuration();
-        config.setEdgeWeightColumn(Boolean.FALSE);
+        Configuration config = Configuration.builder()
+            .edgeWeightColumn(true).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
 
-        config = new Configuration();
-        config.setEdgeWeightColumn(Boolean.TRUE);
-        graphModelImpl.setConfiguration(config);
         Assert.assertTrue(graphModelImpl.store.edgeTable.hasColumn("weight"));
         Assert.assertEquals(graphModelImpl.store.edgeTable.getColumn("weight")
                 .getIndex(), GraphStoreConfiguration.EDGE_WEIGHT_INDEX);
-    }
-
-    @Test
-    public void testSetConfigurationDefaultColumns() {
-        Configuration config = new Configuration();
-        GraphModelImpl graphModelImpl = new GraphModelImpl(config);
-
-        Configuration newConfig = new Configuration();
-        newConfig.setNodeIdType(Integer.class);
-        newConfig.setEdgeIdType(Integer.class);
-        newConfig.setTimeRepresentation(TimeRepresentation.TIMESTAMP);
-        newConfig.setEdgeWeightType(TimestampDoubleMap.class);
-        graphModelImpl.setConfiguration(newConfig);
-
-        Assert.assertSame(graphModelImpl.defaultColumns().nodeId(), graphModelImpl.getNodeTable().getColumn("id"));
-        Assert.assertSame(graphModelImpl.defaultColumns().edgeId(), graphModelImpl.getEdgeTable().getColumn("id"));
-        Assert.assertSame(graphModelImpl.defaultColumns().nodeTimeSet(), graphModelImpl.getNodeTable()
-                .getColumn("timeset"));
-        Assert.assertSame(graphModelImpl.defaultColumns().edgeTimeSet(), graphModelImpl.getEdgeTable()
-                .getColumn("timeset"));
-        Assert.assertSame(graphModelImpl.defaultColumns().edgeWeight(), graphModelImpl.getEdgeTable()
-                .getColumn("weight"));
     }
 
     @Test
@@ -686,34 +615,6 @@ public class GraphModelTest {
         Column col2 = table.addColumn("foo2", String.class);
 
         n1.setAttribute(col2, "test");
-    }
-
-    @Test
-    public void testReplaceEdgeWeightColumnUpdatesConfiguration() {
-        GraphModelImpl graphModel = new GraphModelImpl();
-        Graph graph = graphModel.getGraph();
-
-        Table table = graphModel.getEdgeTable();
-
-        Node n1 = graphModel.factory().newNode("1");
-        Node n2 = graphModel.factory().newNode("2");
-        Edge edge = graphModel.factory().newEdge(n1, n2);
-        graph.addNode(n1);
-        graph.addNode(n2);
-        graph.addEdge(edge);
-
-        Assert.assertTrue(graphModel.getConfiguration().getEdgeWeightColumn());
-        Assert.assertEquals(graphModel.getConfiguration().getEdgeWeightType(), Double.class);
-        Assert.assertFalse(edge.hasDynamicWeight());
-
-        table.removeColumn(GraphStoreConfiguration.EDGE_WEIGHT_COLUMN_ID);
-        Assert.assertFalse(graphModel.getConfiguration().getEdgeWeightColumn());
-
-        table.addColumn(GraphStoreConfiguration.EDGE_WEIGHT_COLUMN_ID, IntervalDoubleMap.class, Origin.PROPERTY);
-
-        Assert.assertTrue(graphModel.getConfiguration().getEdgeWeightColumn());
-        Assert.assertEquals(graphModel.getConfiguration().getEdgeWeightType(), IntervalDoubleMap.class);
-        Assert.assertTrue(edge.hasDynamicWeight());
     }
 
     @Test

--- a/src/test/java/org/gephi/graph/impl/GraphModelTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphModelTest.java
@@ -478,16 +478,15 @@ public class GraphModelTest {
 
     @Test
     public void testGetConfiguration() {
-        Configuration config = new Configuration();
-        config.setNodeIdType(Long.class);
+        Configuration config = Configuration.builder().nodeIdType(Long.class).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
         Assert.assertEquals(graphModelImpl.getConfiguration(), config);
     }
 
     @Test
+    @SuppressWarnings("deprecated")
     public void testGetConfigurationCopy() {
-        Configuration config = new Configuration();
-        config.setNodeIdType(Long.class);
+        Configuration config = Configuration.builder().nodeIdType(Long.class).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
         Assert.assertEquals(graphModelImpl.getConfiguration(), config);
         config.setNodeIdType(Float.class);
@@ -496,9 +495,8 @@ public class GraphModelTest {
 
     @Test
     public void testSetConfigurationIntervals() {
-        Configuration config = Configuration.builder().nodeIdType(Integer.class)
-            .edgeIdType(Byte.class)
-            .timeRepresentation(TimeRepresentation.INTERVAL).build();
+        Configuration config = Configuration.builder().nodeIdType(Integer.class).edgeIdType(Byte.class)
+                .timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
         Assert.assertEquals(graphModelImpl.getConfiguration(), config);
         Assert.assertEquals(graphModelImpl.getNodeTable().getColumn("id").getTypeClass(), Integer.class);
@@ -518,9 +516,8 @@ public class GraphModelTest {
 
     @Test
     public void testSetConfigurationTimestamps() {
-        Configuration config = Configuration.builder().nodeIdType(Integer.class)
-            .edgeIdType(Byte.class)
-            .timeRepresentation(TimeRepresentation.TIMESTAMP).build();
+        Configuration config = Configuration.builder().nodeIdType(Integer.class).edgeIdType(Byte.class)
+                .timeRepresentation(TimeRepresentation.TIMESTAMP).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
         Assert.assertEquals(graphModelImpl.getConfiguration(), config);
         Assert.assertEquals(graphModelImpl.getNodeTable().getColumn("id").getTypeClass(), Integer.class);
@@ -540,15 +537,15 @@ public class GraphModelTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadEdgeWeightTypeConfigurationIntervals() {
-        Configuration config = Configuration.builder()
-            .timeRepresentation(TimeRepresentation.INTERVAL).edgeWeightType(TimestampDoubleMap.class).build();
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
+                .edgeWeightType(TimestampDoubleMap.class).build();
         new GraphModelImpl(config);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadEdgeWeightTypeConfigurationTimestamps() {
-        Configuration config = Configuration.builder()
-            .timeRepresentation(TimeRepresentation.TIMESTAMP).edgeWeightType(IntervalDoubleMap.class).build();
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.TIMESTAMP)
+                .edgeWeightType(IntervalDoubleMap.class).build();
         new GraphModelImpl(config);
     }
 
@@ -560,8 +557,7 @@ public class GraphModelTest {
 
     @Test
     public void testSetConfigurationEdgeWeightColumnFalse() {
-        Configuration config = Configuration.builder()
-            .edgeWeightColumn(false).build();
+        Configuration config = Configuration.builder().edgeWeightColumn(false).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
 
         Assert.assertFalse(graphModelImpl.store.edgeTable.hasColumn("weight"));
@@ -571,8 +567,7 @@ public class GraphModelTest {
 
     @Test
     public void testSetConfigurationEdgeWeightColumnTrue() {
-        Configuration config = Configuration.builder()
-            .edgeWeightColumn(true).build();
+        Configuration config = Configuration.builder().edgeWeightColumn(true).build();
         GraphModelImpl graphModelImpl = new GraphModelImpl(config);
 
         Assert.assertTrue(graphModelImpl.store.edgeTable.hasColumn("weight"));

--- a/src/test/java/org/gephi/graph/impl/GraphStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphStoreTest.java
@@ -473,7 +473,7 @@ public class GraphStoreTest {
         NodeImpl[] nodes = GraphGenerator.generateNodeList(2);
         graphStore.addAllNodes(Arrays.asList(nodes));
 
-        EdgeImpl edge = new EdgeImpl("0", nodes[0], nodes[1], 0, 1.0, true);
+        EdgeImpl edge = new EdgeImpl("0", graphStore, nodes[0], nodes[1], 0, 1.0, true);
         boolean a = graphStore.addEdge(edge);
         boolean b = graphStore.addEdge(edge);
 
@@ -491,8 +491,8 @@ public class GraphStoreTest {
         NodeImpl[] nodes = GraphGenerator.generateNodeList(2);
         graphStore.addAllNodes(Arrays.asList(nodes));
 
-        EdgeImpl edge1 = new EdgeImpl("0", nodes[0], nodes[1], 0, 1.0, true);
-        EdgeImpl edge2 = new EdgeImpl("1", nodes[0], nodes[1], 0, 1.0, true);
+        EdgeImpl edge1 = new EdgeImpl("0", graphStore, nodes[0], nodes[1], 0, 1.0, true);
+        EdgeImpl edge2 = new EdgeImpl("1", graphStore, nodes[0], nodes[1], 0, 1.0, true);
         boolean a = graphStore.addEdge(edge1);
         boolean b = graphStore.addEdge(edge2);
 
@@ -512,7 +512,7 @@ public class GraphStoreTest {
         EdgeTypeStore typeStore = graphStore.edgeTypeStore;
         Assert.assertFalse(typeStore.contains(1));
 
-        EdgeImpl edge = new EdgeImpl("0", nodes[0], nodes[1], 1, 1.0, true);
+        EdgeImpl edge = new EdgeImpl("0", graphStore, nodes[0], nodes[1], 1, 1.0, true);
         graphStore.addEdge(edge);
 
         Assert.assertTrue(typeStore.contains(1));
@@ -525,7 +525,7 @@ public class GraphStoreTest {
         NodeImpl[] nodes = GraphGenerator.generateNodeList(2);
         graphStore.addAllNodes(Arrays.asList(nodes));
 
-        EdgeImpl edge = new EdgeImpl("0", nodes[0], nodes[1], 0, 1.0, true);
+        EdgeImpl edge = new EdgeImpl("0", graphStore, nodes[0], nodes[1], 0, 1.0, true);
         graphStore.addAllEdges(Collections.singletonList(edge));
 
         Assert.assertTrue(graphStore.contains(edge));
@@ -537,7 +537,7 @@ public class GraphStoreTest {
         NodeImpl[] nodes = GraphGenerator.generateNodeList(2);
         graphStore.addAllNodes(Arrays.asList(nodes));
 
-        EdgeImpl edge = new EdgeImpl("0", nodes[0], nodes[1], 1, 1.0, true);
+        EdgeImpl edge = new EdgeImpl("0", graphStore, nodes[0], nodes[1], 1, 1.0, true);
         graphStore.addAllEdges(Collections.singletonList(edge));
 
         Assert.assertTrue(graphStore.edgeTypeStore.contains(1));

--- a/src/test/java/org/gephi/graph/impl/IndexImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/IndexImplTest.java
@@ -65,10 +65,10 @@ public class IndexImplTest {
     @Test
     public void testHasColumnDifferentIndex() {
         TableImpl<Node> nodeTable = generateEmptyNodeTable();
-        IndexImpl<Node> index1 = columnStore1.indexStore.mainIndex;
+        IndexImpl<Node> index1 = nodeTable.store.indexStore.mainIndex;
 
-        ColumnStore<Node> columnStore2 = generateEmptyNodeStore();
-        IndexImpl<Node> index2 = columnStore2.indexStore.mainIndex;
+        TableImpl<Node> nodeTable2 = generateEmptyNodeTable();
+        IndexImpl<Node> index2 = nodeTable2.store.indexStore.mainIndex;
 
         ColumnImpl col1 = new ColumnImpl("foo", String.class, "foo", null, Origin.DATA, true, false);
         ColumnImpl col2 = new ColumnImpl("bar", String.class, "bar", null, Origin.DATA, true, false);
@@ -84,7 +84,7 @@ public class IndexImplTest {
     @Test
     public void testAddAllColumns() {
         TableImpl<Node> nodeTable = generateEmptyNodeTable();
-        IndexImpl<Node> index = columnStore.indexStore.mainIndex;
+        IndexImpl<Node> index = nodeTable.store.indexStore.mainIndex;
         ColumnImpl col1 = new ColumnImpl("1", String.class, "1", null, Origin.DATA, true, false);
         ColumnImpl col2 = new ColumnImpl("2", String.class, "2", null, Origin.DATA, false, false);
         ColumnImpl col3 = new ColumnImpl("3", String.class, "3", null, Origin.DATA, true, false);
@@ -99,7 +99,7 @@ public class IndexImplTest {
     @Test
     public void testDestroy() {
         TableImpl<Node> nodeTable = generateEmptyNodeTable();
-        IndexImpl<Node> index = columnStore.indexStore.mainIndex;
+        IndexImpl<Node> index = nodeTable.store.indexStore.mainIndex;
         ColumnImpl col1 = new ColumnImpl("1", String.class, "1", null, Origin.DATA, true, false);
         ColumnImpl col2 = new ColumnImpl("2", String.class, "2", null, Origin.DATA, false, false);
         col1.setStoreId(0);

--- a/src/test/java/org/gephi/graph/impl/IndexImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/IndexImplTest.java
@@ -19,6 +19,7 @@ package org.gephi.graph.impl;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Node;
 import org.gephi.graph.api.Origin;
+import org.gephi.graph.api.Table;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,16 +27,16 @@ public class IndexImplTest {
 
     @Test
     public void testIndexName() {
-        ColumnStore<Node> columnStore = generateEmptyNodeStore();
-        IndexImpl<Node> index = columnStore.indexStore.mainIndex;
+        TableImpl<Node> nodeTable = generateEmptyNodeTable();
+        IndexImpl<Node> index = nodeTable.store.indexStore.mainIndex;
         Assert.assertEquals(index.getIndexClass(), Node.class);
         Assert.assertEquals(index.getIndexName(), "index_" + Node.class.getCanonicalName());
     }
 
     @Test
     public void testAddColumn() {
-        ColumnStore<Node> columnStore = generateEmptyNodeStore();
-        IndexImpl<Node> index = columnStore.indexStore.mainIndex;
+        TableImpl<Node> nodeTable = generateEmptyNodeTable();
+        IndexImpl<Node> index = nodeTable.store.indexStore.mainIndex;
         ColumnImpl col = new ColumnImpl("foo", String.class, "foo", null, Origin.DATA, true, false);
         col.setStoreId(0);
 
@@ -47,8 +48,8 @@ public class IndexImplTest {
 
     @Test
     public void testHasColumn() {
-        ColumnStore<Node> columnStore = generateEmptyNodeStore();
-        IndexImpl<Node> index = columnStore.indexStore.mainIndex;
+        TableImpl<Node> nodeTable = generateEmptyNodeTable();
+        IndexImpl<Node> index = nodeTable.store.indexStore.mainIndex;
         ColumnImpl col1 = new ColumnImpl("foo", String.class, "foo", null, Origin.DATA, true, false);
         ColumnImpl col2 = new ColumnImpl("bar", String.class, "bar", null, Origin.DATA, false, false);
         col1.setStoreId(0);
@@ -63,7 +64,7 @@ public class IndexImplTest {
 
     @Test
     public void testHasColumnDifferentIndex() {
-        ColumnStore<Node> columnStore1 = generateEmptyNodeStore();
+        TableImpl<Node> nodeTable = generateEmptyNodeTable();
         IndexImpl<Node> index1 = columnStore1.indexStore.mainIndex;
 
         ColumnStore<Node> columnStore2 = generateEmptyNodeStore();
@@ -82,7 +83,7 @@ public class IndexImplTest {
 
     @Test
     public void testAddAllColumns() {
-        ColumnStore<Node> columnStore = generateEmptyNodeStore();
+        TableImpl<Node> nodeTable = generateEmptyNodeTable();
         IndexImpl<Node> index = columnStore.indexStore.mainIndex;
         ColumnImpl col1 = new ColumnImpl("1", String.class, "1", null, Origin.DATA, true, false);
         ColumnImpl col2 = new ColumnImpl("2", String.class, "2", null, Origin.DATA, false, false);
@@ -97,7 +98,7 @@ public class IndexImplTest {
 
     @Test
     public void testDestroy() {
-        ColumnStore<Node> columnStore = generateEmptyNodeStore();
+        TableImpl<Node> nodeTable = generateEmptyNodeTable();
         IndexImpl<Node> index = columnStore.indexStore.mainIndex;
         ColumnImpl col1 = new ColumnImpl("1", String.class, "1", null, Origin.DATA, true, false);
         ColumnImpl col2 = new ColumnImpl("2", String.class, "2", null, Origin.DATA, false, false);
@@ -130,8 +131,8 @@ public class IndexImplTest {
         Assert.assertNotNull(edgeIndex.getIndex(graphStore.getModel().defaultColumns().edgeTimeSet()));
     }
 
-    private ColumnStore<Node> generateEmptyNodeStore() {
+    private TableImpl<Node> generateEmptyNodeTable() {
         GraphStore graphStore = GraphGenerator.generateEmptyGraphStore();
-        return graphStore.nodeTable.store;
+        return graphStore.nodeTable;
     }
 }

--- a/src/test/java/org/gephi/graph/impl/IntervalIndexImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/IntervalIndexImplTest.java
@@ -31,8 +31,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testGetMin() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -73,8 +72,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testGetMax() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -92,8 +90,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testGetMinWithInfinite() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -107,8 +104,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testGetMaxWithInfinite() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -122,8 +118,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testGetElements() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -170,8 +165,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testHasNodesEdgesEmpty() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -180,8 +174,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testHasNodes() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;
@@ -204,8 +197,7 @@ public class IntervalIndexImplTest {
 
     @Test
     public void testHasNodesClear() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timeStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timeStore.nodeIndexStore;

--- a/src/test/java/org/gephi/graph/impl/IntervalIndexStoreTest.java
+++ b/src/test/java/org/gephi/graph/impl/IntervalIndexStoreTest.java
@@ -261,8 +261,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testIndexNode() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -281,8 +280,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testIndexNodeAdd() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -301,8 +299,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testClearNode() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -323,8 +320,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testClearNodeWithAttributes() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -341,8 +337,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testClearRemove() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -362,8 +357,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testAddAfterAdd() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -383,8 +377,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testRemoveAfterAdd() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -409,8 +402,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testSetAttribute() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -437,8 +429,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testRemoveAttributeTimestamp() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -455,8 +446,7 @@ public class IntervalIndexStoreTest {
 
     @Test
     public void testAddWithAttribute() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphStore graphStore = new GraphModelImpl(config).store;
         TimeStore timestampStore = graphStore.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -492,8 +482,7 @@ public class IntervalIndexStoreTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testCreateViewMainView() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;
@@ -502,8 +491,7 @@ public class IntervalIndexStoreTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testDeleteViewMainView() {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         TimeStore timestampStore = graphModel.store.timeStore;
         IntervalIndexStore store = (IntervalIndexStore) timestampStore.nodeIndexStore;

--- a/src/test/java/org/gephi/graph/impl/NodeImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/NodeImplTest.java
@@ -1,0 +1,26 @@
+package org.gephi.graph.impl;
+
+import org.gephi.graph.api.Configuration;
+import org.gephi.graph.api.Node;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class NodeImplTest {
+
+    @Test
+    public void testProperties() {
+        GraphStore graphStore = GraphGenerator.generateTinyGraphStore();
+        Node n = graphStore.getNode("1");
+        Assert.assertNotNull(n.getTextProperties());
+        Assert.assertNotNull(n.getColor());
+        Assert.assertEquals(n.alpha(), 1f);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testPropertiesDisabled() {
+        GraphStore graphStore = GraphGenerator
+                .generateTinyGraphStore(Configuration.builder().enableNodeProperties(false).build());
+        Node n = graphStore.getNode("1");
+        Assert.assertNull(n.getColor());
+    }
+}

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -745,9 +745,8 @@ public class SerializationTest {
         Serialization ser = new Serialization(graphModel);
         byte[] buf = ser.serialize(graphModel.configuration);
 
-        graphModel = new GraphModelImpl();
-        ser = new Serialization(graphModel);
-        Configuration l = (Configuration) ser.deserialize(buf);
+        ser = new Serialization(new GraphModelImpl());
+        ConfigurationImpl l = (ConfigurationImpl) ser.deserialize(buf);
         Assert.assertTrue(graphModel.configuration.equals(l));
     }
 
@@ -1211,6 +1210,7 @@ public class SerializationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         GraphModelImpl gm = GraphGenerator.generateSmallUndirectedGraphStore().graphModel;
+
         Serialization ser = new Serialization(gm);
 
         DataInputOutput dio = new DataInputOutput();
@@ -1221,6 +1221,8 @@ public class SerializationTest {
         Assert.assertSame(read.defaultColumns().nodeId(), read.getNodeTable().getColumn("id"));
         Assert.assertSame(read.defaultColumns().nodeLabel(), read.getNodeTable().getColumn("label"));
         Assert.assertSame(read.defaultColumns().edgeId(), read.getEdgeTable().getColumn("id"));
+        Assert.assertSame(read.defaultColumns().edgeLabel(), read.getEdgeTable().getColumn("label"));
+        Assert.assertSame(read.defaultColumns().edgeWeight(), read.getEdgeTable().getColumn("weight"));
     }
 
     @Test

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -713,8 +713,7 @@ public class SerializationTest {
 
     @Test
     public void testIntervalStore() throws IOException, ClassNotFoundException {
-        Configuration config = new Configuration();
-        config.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        Configuration config = Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL).build();
         GraphModelImpl graphModel = new GraphModelImpl(config);
         GraphStore store = graphModel.store;
         TimeStore timestampStore = store.timeStore;
@@ -737,10 +736,8 @@ public class SerializationTest {
 
     @Test
     public void testConfiguration() throws IOException, ClassNotFoundException {
-        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder()
-            .nodeIdType(Float.class)
-            .edgeIdType(Long.class)
-            .timeRepresentation(TimeRepresentation.INTERVAL).build());
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().nodeIdType(Float.class)
+                .edgeIdType(Long.class).timeRepresentation(TimeRepresentation.INTERVAL).build());
 
         Serialization ser = new Serialization(graphModel);
         byte[] buf = ser.serialize(graphModel.configuration);

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -737,20 +737,18 @@ public class SerializationTest {
 
     @Test
     public void testConfiguration() throws IOException, ClassNotFoundException {
-        GraphModelImpl graphModel = new GraphModelImpl();
-        Configuration configuration = graphModel.configuration;
-
-        configuration.setNodeIdType(Float.class);
-        configuration.setEdgeIdType(Long.class);
-        configuration.setTimeRepresentation(TimeRepresentation.INTERVAL);
+        GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder()
+            .nodeIdType(Float.class)
+            .edgeIdType(Long.class)
+            .timeRepresentation(TimeRepresentation.INTERVAL).build());
 
         Serialization ser = new Serialization(graphModel);
-        byte[] buf = ser.serialize(configuration);
+        byte[] buf = ser.serialize(graphModel.configuration);
 
         graphModel = new GraphModelImpl();
         ser = new Serialization(graphModel);
         Configuration l = (Configuration) ser.deserialize(buf);
-        Assert.assertTrue(configuration.equals(l));
+        Assert.assertTrue(graphModel.configuration.equals(l));
     }
 
     @Test

--- a/src/test/java/org/gephi/graph/impl/SpatialIndexImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/SpatialIndexImplTest.java
@@ -1,15 +1,13 @@
 package org.gephi.graph.impl;
 
 import java.util.Arrays;
+import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.EdgeIterable;
 import org.gephi.graph.api.Node;
 import org.gephi.graph.api.NodeIterable;
 import org.gephi.graph.api.Rect2D;
 import org.testng.Assert;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class SpatialIndexImplTest {
@@ -17,22 +15,15 @@ public class SpatialIndexImplTest {
     private static final float BOUNDS = 1000f;
     private static final Rect2D BOUNDS_RECT = new Rect2D(-BOUNDS, -BOUNDS, BOUNDS, BOUNDS);
 
-    @BeforeMethod
-    public void setUp() {
-        if (!GraphStoreConfiguration.ENABLE_SPATIAL_INDEX) {
-            throw new SkipException("Skip spatial index tests because feature is disabled");
-        }
-    }
-
     @Test
     public void testGetEdgesEmpty() {
-        SpatialIndexImpl spatialIndex = new GraphStore().spatialIndex;
+        SpatialIndexImpl spatialIndex = new GraphStore(null, getConfig()).spatialIndex;
         Assert.assertTrue(spatialIndex.getEdgesInArea(BOUNDS_RECT).toCollection().isEmpty());
     }
 
     @Test
     public void testGetElementsBothNodesVisible() {
-        GraphStore store = GraphGenerator.generateTinyGraphStore();
+        GraphStore store = GraphGenerator.generateTinyGraphStore(getConfig());
 
         NodeImpl n1 = store.getNode("1");
         NodeImpl n2 = store.getNode("2");
@@ -45,7 +36,7 @@ public class SpatialIndexImplTest {
 
     @Test
     public void testGetElementsOneNodeVisible() {
-        GraphStore store = GraphGenerator.generateTinyGraphStore();
+        GraphStore store = GraphGenerator.generateTinyGraphStore(getConfig());
 
         NodeImpl n1 = store.getNode("1");
         n1.setPosition(300000f, 300000f);
@@ -59,7 +50,7 @@ public class SpatialIndexImplTest {
 
     @Test
     public void testGetElementsWithoutNodeVisible() {
-        GraphStore store = GraphGenerator.generateTinyGraphStore();
+        GraphStore store = GraphGenerator.generateTinyGraphStore(getConfig());
 
         NodeImpl n1 = store.getNode("1");
         n1.setPosition(300000f, 300000f);
@@ -74,7 +65,7 @@ public class SpatialIndexImplTest {
 
     @Test
     public void testGetElementsWithSelfLoop() {
-        GraphStore store = GraphGenerator.generateTinyGraphStoreWithSelfLoop();
+        GraphStore store = GraphGenerator.generateTinyGraphStoreWithSelfLoop(getConfig());
 
         NodeImpl n1 = store.getNode("1");
         EdgeImpl e = store.getEdge("0");
@@ -90,5 +81,10 @@ public class SpatialIndexImplTest {
 
     private void assertSame(EdgeIterable iterable, Edge... expected) {
         Assert.assertEquals(iterable.toCollection(), Arrays.asList(expected));
+    }
+
+    // Configuration with spatial index
+    private Configuration getConfig() {
+        return Configuration.builder().enableSpatialIndex(true).build();
     }
 }

--- a/src/test/java/org/gephi/graph/impl/SpatialIndexImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/SpatialIndexImplTest.java
@@ -16,6 +16,12 @@ public class SpatialIndexImplTest {
     private static final Rect2D BOUNDS_RECT = new Rect2D(-BOUNDS, -BOUNDS, BOUNDS, BOUNDS);
 
     @Test
+    public void testDisabled() {
+        GraphStore store = GraphGenerator.generateEmptyGraphStore();
+        Assert.assertNull(store.spatialIndex);
+    }
+
+    @Test
     public void testGetEdgesEmpty() {
         SpatialIndexImpl spatialIndex = new GraphStore(null, getConfig()).spatialIndex;
         Assert.assertTrue(spatialIndex.getEdgesInArea(BOUNDS_RECT).toCollection().isEmpty());

--- a/src/test/java/org/gephi/graph/impl/TableImplTest.java
+++ b/src/test/java/org/gephi/graph/impl/TableImplTest.java
@@ -28,7 +28,7 @@ public class TableImplTest {
 
     @Test
     public void testTable() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Assert.assertEquals(table.countColumns(), 0);
         Assert.assertEquals(table.size(), 0);
         Assert.assertTrue(table.isEmpty());
@@ -36,7 +36,7 @@ public class TableImplTest {
 
     @Test
     public void testAddColumnDefault() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
 
         Assert.assertEquals(table.countColumns(), 1);
@@ -47,7 +47,7 @@ public class TableImplTest {
 
     @Test
     public void testAddColumnWithOrigin() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class, Origin.PROPERTY);
         Assert.assertEquals(col.getOrigin(), Origin.PROPERTY);
         Assert.assertTrue(col.isProperty());
@@ -55,7 +55,7 @@ public class TableImplTest {
 
     @Test
     public void testAddColumnWithTitleAndDefaultValue() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", "Foo", Integer.class, 42);
         Assert.assertEquals(col.getTitle(), "Foo");
         Assert.assertEquals(col.getDefaultValue(), 42);
@@ -63,13 +63,13 @@ public class TableImplTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUnknownType() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         table.addColumn("Id", Node.class);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testDefaultValueWrongType() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Float defaultValue = 25f;
 
         table.addColumn("Id", null, Integer.class, Origin.DATA, defaultValue, false);
@@ -77,28 +77,28 @@ public class TableImplTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testOriginCantBeNull() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
 
         table.addColumn("Id", null, Integer.class, null, 0, false);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testOriginCantBeNull2() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
 
         table.addColumn("Id", Integer.class, null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testTypeClassCantBeNull() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
 
         table.addColumn("Id", null, null, Origin.DATA, 0, false);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testTypeClassCantBeNull2() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
 
         table.addColumn("Id", null);
     }
@@ -106,7 +106,7 @@ public class TableImplTest {
     @Test
     public void testIsIndexed() {
         GraphStore graphStore = new GraphStore();
-        TableImpl<Node> table = new TableImpl<>(graphStore, Node.class, true);
+        TableImpl<Node> table = new TableImpl<>(graphStore, Node.class);
         Column col1 = table.addColumn("Id", null, Integer.class, Origin.DATA, null, false);
         Column col2 = table.addColumn("1", null, Integer.class, Origin.DATA, null, true);
         Column col3 = table.addColumn("2", null, TimestampIntegerMap.class, Origin.DATA, null, true);
@@ -120,7 +120,7 @@ public class TableImplTest {
 
     @Test
     public void testGetColumnId() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
 
         Column c1 = table.getColumn("Id");
@@ -131,13 +131,13 @@ public class TableImplTest {
 
     @Test
     public void testGetColumnBadId() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Assert.assertNull(table.getColumn("Id"));
     }
 
     @Test
     public void testGetColumnIndex() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
 
         Column c = table.getColumn(0);
@@ -146,7 +146,7 @@ public class TableImplTest {
 
     @Test
     public void testHasColumn() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         table.addColumn("Id", Integer.class);
 
         Assert.assertTrue(table.hasColumn("Id"));
@@ -157,7 +157,7 @@ public class TableImplTest {
 
     @Test
     public void testContains() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
 
         Assert.assertTrue(table.contains(col));
@@ -165,40 +165,40 @@ public class TableImplTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testGetColumnBadIndex() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         table.getColumn(0);
     }
 
     @Test
     public void testTitleBackFill() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
         Assert.assertEquals(col.getTitle(), "Id");
     }
 
     @Test
     public void testIdLowercase() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("A", Integer.class);
         Assert.assertEquals(col.getId(), "a");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNonStandardType() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         table.addColumn("Id", Color.class);
     }
 
     @Test
     public void testStandardizePrimitiveType() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", int.class);
         Assert.assertEquals(col.getTypeClass(), Integer.class);
     }
 
     @Test
     public void testStandardizeArrayType() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("test_col"/*
                                                 * Id does not allow non-simple types
                                                 */, Integer[].class);
@@ -207,7 +207,7 @@ public class TableImplTest {
 
     @Test
     public void testStandardizeArrayDefaultValue() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Integer[] t = new Integer[] { 1, 2 };
 
         Column col = table.addColumn("test_col"/*
@@ -220,7 +220,7 @@ public class TableImplTest {
 
     @Test
     public void testRemoveColumn() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
 
         table.removeColumn(col);
@@ -230,7 +230,7 @@ public class TableImplTest {
 
     @Test
     public void testRemove() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
 
         table.remove(col);
@@ -239,7 +239,7 @@ public class TableImplTest {
 
     @Test
     public void testRemoveColumnString() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         table.addColumn("Id", Integer.class);
 
         table.removeColumn("Id");
@@ -253,7 +253,7 @@ public class TableImplTest {
 
     @Test
     public void testCountColumns() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         table.addColumn("Id", Integer.class);
 
         table.removeColumn("Id");
@@ -263,37 +263,37 @@ public class TableImplTest {
 
     @Test
     public void testGetElementClass() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Assert.assertEquals(table.getElementClass(), Node.class);
     }
 
     @Test
     public void testToArray() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
         Assert.assertEquals(table.toArray(), new Column[] { col });
     }
 
     @Test
     public void testToArrayFromCollection() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
         Assert.assertEquals(table.toArray(new Column[0]), new Column[] { col });
     }
 
     @Test
     public void testToList() {
-        TableImpl<Node> table = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table = new TableImpl<>(Node.class);
         Column col = table.addColumn("Id", Integer.class);
         Assert.assertEquals(table.toList(), Arrays.asList(new Column[] { col }));
     }
 
     @Test
     public void testDeepEquals() {
-        TableImpl<Node> table1 = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table1 = new TableImpl<>(Node.class);
         table1.addColumn("Id", Integer.class);
 
-        TableImpl<Node> table2 = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table2 = new TableImpl<>(Node.class);
         table2.addColumn("Id", Integer.class);
 
         Assert.assertTrue(table1.deepEquals(table2));
@@ -301,10 +301,10 @@ public class TableImplTest {
 
     @Test
     public void testDeepHashCode() {
-        TableImpl<Node> table1 = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table1 = new TableImpl<>(Node.class);
         table1.addColumn("Id", Integer.class);
 
-        TableImpl<Node> table2 = new TableImpl<>(Node.class, false);
+        TableImpl<Node> table2 = new TableImpl<>(Node.class);
         table2.addColumn("Id", Integer.class);
 
         Assert.assertEquals(table1.deepHashCode(), table2.deepHashCode());

--- a/src/test/java/org/gephi/graph/impl/TableObserverTest.java
+++ b/src/test/java/org/gephi/graph/impl/TableObserverTest.java
@@ -28,7 +28,7 @@ public class TableObserverTest {
 
     @Test
     public void testDefaultObserver() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(false);
 
         Assert.assertFalse(tableObserver.destroyed);
@@ -40,7 +40,7 @@ public class TableObserverTest {
 
     @Test
     public void testObserverAddColumn() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(false);
 
         table.addColumn("0", Integer.class);
@@ -51,7 +51,7 @@ public class TableObserverTest {
 
     @Test
     public void testObserverRemoveColumn() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         table.addColumn("0", Integer.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(false);
         table.removeColumn("0");
@@ -62,7 +62,7 @@ public class TableObserverTest {
 
     @Test
     public void testObserverModifyColumn() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         Column col = table.addColumn("0", TimestampIntegerMap.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(false);
         col.setEstimator(Estimator.MAX);
@@ -73,7 +73,7 @@ public class TableObserverTest {
 
     @Test
     public void testDestroyObserver() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(false);
 
         tableObserver.destroy();
@@ -84,21 +84,21 @@ public class TableObserverTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testGetDiffWithoutSetting() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(false);
         tableObserver.getDiff();
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testGetDiffWithoutHasGraphChanged() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(true);
         tableObserver.getDiff();
     }
 
     @Test
     public void testDiffRemoveColumn() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         table.addColumn("0", Integer.class);
         Column[] columns = table.toArray();
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(true);
@@ -115,7 +115,7 @@ public class TableObserverTest {
 
     @Test
     public void testDiffAddColumn() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(true);
         table.addColumn("0", Integer.class);
         Column[] columns = table.toArray();
@@ -131,7 +131,7 @@ public class TableObserverTest {
 
     @Test
     public void testDiffModifyColumn() {
-        TableImpl table = new TableImpl(Node.class, false);
+        TableImpl table = new TableImpl(Node.class);
         Column col = table.addColumn("0", TimestampIntegerMap.class);
         TableObserverImpl tableObserver = (TableObserverImpl) table.createTableObserver(true);
         col.setEstimator(Estimator.AVERAGE);


### PR DESCRIPTION
Configuration is a bit cumbersome to use
- [x] Create Configuration builder to facilitate unit test
- [x] Deprecate setters on the `Configuration` class in profit of the builder
- [x] Move relevant static configuration to `Configuration`
- [x] Add unit tests for different configurations
- [x] Update documentation

#162 