### PR TITLE
Harden serialization: fail on unknown tags, fix char encoding

### DIFF
--- a/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -56,7 +56,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.gephi.graph.api.Configuration;
@@ -178,6 +177,8 @@ public class Serialization {
     final static int STRING_EMPTY = 101;
     final static int NOTUSED_STRING_255 = 102;
     final static int STRING = 103;
+    // Reserved, do not reuse: was java.util.Locale, removed because Locale isn't an
+    // AttributeUtils supported type. Kept so old streams can still be identified.
     final static int LOCALE = 124;
     final static int PROPERTIES = 125;
     final static int CLASS = 126;
@@ -1470,7 +1471,9 @@ public class Serialization {
             }
         } else if (clazz == Character.class) {
             out.write(CHAR);
-            out.writeChar((Character) obj);
+            // Write as 2-byte short so the encoding doesn't depend on the DataOutput
+            // implementation. Byte-identical to DataOutputStream.writeChar().
+            out.writeShort((Character) obj);
 
         } else if (clazz == String.class) {
             String s = (String) obj;
@@ -1520,7 +1523,8 @@ public class Serialization {
             char[] a = (char[]) obj;
             LongPacker.packInt(out, a.length);
             for (char s : a) {
-                out.writeChar(s);
+                // See CHAR above: 2-byte encoding, independent of the DataOutput impl.
+                out.writeShort(s);
             }
         } else if (obj instanceof byte[]) {
             byte[] b = (byte[]) obj;
@@ -1531,12 +1535,6 @@ public class Serialization {
             out.write(DATE);
             out.writeLong(((Date) obj).getTime());
 
-        } else if (clazz == Locale.class) {
-            out.write(LOCALE);
-            Locale l = (Locale) obj;
-            out.writeUTF(l.getLanguage());
-            out.writeUTF(l.getCountry());
-            out.writeUTF(l.getVariant());
         } else if (obj instanceof String[]) {
             String[] b = (String[]) obj;
             out.write(STRING_ARRAY);
@@ -2023,11 +2021,11 @@ public class Serialization {
                 size = LongPacker.unpackInt(is);
                 ret = new char[size];
                 for (int i = 0; i < size; i++) {
-                    ((char[]) ret)[i] = is.readChar();
+                    ((char[]) ret)[i] = (char) is.readUnsignedShort();
                 }
                 break;
             case CHAR:
-                ret = is.readChar();
+                ret = Character.valueOf((char) is.readUnsignedShort());
                 break;
             case FLOAT_MINUS_1:
                 ret = Float.valueOf(-1);
@@ -2115,9 +2113,6 @@ public class Serialization {
                 break;
             case ARRAY_BYTE_INT:
                 ret = deserializeArrayByteInt(is);
-                break;
-            case LOCALE:
-                ret = new Locale(is.readUTF(), is.readUTF(), is.readUTF());
                 break;
             case STRING_ARRAY:
                 ret = deserializeStringArray(is);
@@ -2224,9 +2219,8 @@ public class Serialization {
             case INSTANT:
                 ret = deserializeInstant(is);
                 break;
-            case -1:
-                throw new EOFException();
-
+            default:
+                throw new IOException("Unknown serialization type tag: " + head);
         }
         return ret;
     }

--- a/src/main/java/org/gephi/graph/impl/utils/DataInputOutput.java
+++ b/src/main/java/org/gephi/graph/impl/utils/DataInputOutput.java
@@ -124,7 +124,7 @@ public final class DataInputOutput implements DataInput, DataOutput, ObjectInput
 
     @Override
     public char readChar() throws IOException {
-        return (char) readInt();
+        return (char) readUnsignedShort();
     }
 
     @Override
@@ -209,7 +209,7 @@ public final class DataInputOutput implements DataInput, DataOutput, ObjectInput
 
     @Override
     public void writeChar(int v) throws IOException {
-        writeInt(v);
+        writeShort(v);
     }
 
     @Override

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -42,6 +42,8 @@ import it.unimi.dsi.fastutil.shorts.ShortArrayList;
 import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -53,7 +55,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -1185,14 +1186,6 @@ public class SerializationTest {
     }
 
     @Test
-    public void testLocale() throws Exception {
-        Serialization ser = new Serialization(null);
-        Assert.assertEquals(Locale.FRANCE, ser.deserialize(ser.serialize(Locale.FRANCE)));
-        Assert.assertEquals(Locale.CANADA_FRENCH, ser.deserialize(ser.serialize(Locale.CANADA_FRENCH)));
-        Assert.assertEquals(Locale.SIMPLIFIED_CHINESE, ser.deserialize(ser.serialize(Locale.SIMPLIFIED_CHINESE)));
-    }
-
-    @Test
     public void testSmallGraphModel() throws Exception {
         GraphModelImpl gm = GraphGenerator.generateSmallGraphStore().graphModel;
         Serialization ser = new Serialization(gm);
@@ -1312,6 +1305,26 @@ public class SerializationTest {
 
             BitSet deserializedBs = ser.deserializeBitSet(dio.reset(bytes));
             Assert.assertEquals(bs, deserializedBs);
+        }
+    }
+
+    @Test
+    public void testSerializationTagsAreUnique() throws Exception {
+        // NULL_ID is excluded: it's an idMap sentinel (-1), not a wire tag
+        Map<Integer, String> tagsByValue = new HashMap<>();
+        for (Field field : Serialization.class.getDeclaredFields()) {
+            int modifiers = field.getModifiers();
+            if (!Modifier.isStatic(modifiers) || !Modifier.isFinal(modifiers) || field.getType() != int.class) {
+                continue;
+            }
+            String name = field.getName();
+            if (name.equals("NULL_ID")) {
+                continue;
+            }
+            field.setAccessible(true);
+            int value = field.getInt(null);
+            String previous = tagsByValue.put(value, name);
+            Assert.assertNull(previous, "Duplicate serialization tag " + value + " shared by " + previous + " and " + name);
         }
     }
 }

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -1000,7 +1000,10 @@ public class SerializationTest {
     @Test
     public void testChar() throws IOException, ClassNotFoundException {
         Serialization ser = new Serialization(null);
-        char[] vals = { 'a', ' ' };
+        // Chars are written as a 2-byte short, so cover the boundaries of that
+        // range: above 0x7F, above 0x7FF, either side of the signed-short flip,
+        // the 16-bit maximum, and an unpaired surrogate
+        char[] vals = { 'a', ' ', '\u00e9', '\u4e2d', '\u7fff', '\u8000', '\uffff', '\ud83d' };
         for (char i : vals) {
             byte[] buf = ser.serialize(i);
             Object l2 = ser.deserialize(buf);
@@ -1145,7 +1148,7 @@ public class SerializationTest {
     @Test
     public void testCharArray() throws ClassNotFoundException, IOException {
         Serialization ser = new Serialization(null);
-        char[] l = new char[] { '1', 'a', '&' };
+        char[] l = new char[] { '1', 'a', '&', '\u00e9', '\u4e2d', '\u8000', '\uffff' };
         Object deserialize = ser.deserialize(ser.serialize(l));
         Assert.assertTrue(Arrays.equals(l, (char[]) deserialize));
     }


### PR DESCRIPTION
Three scoped fixes to the serialization layer. **No change to the on-disk format**, so no `VERSION` bump.

### Unknown type tags now fail loudly

`deserialize()` had no `default:` case, so an unrecognized tag silently returned `null` — surfacing later as a confusing `ClassCastException` or silent data loss. It now throws `IOException` naming the tag. The preceding `case -1` was unreachable (`readUnsignedByte` never returns -1) and is removed.

Verified that every tag written by `serialize()` has a matching `case` in `deserialize()`, so this can only fire on corrupt or newer-format input.

### `char` encoding no longer depends on the stream implementation

`CHAR` and `CHAR_ARRAY` used `DataOutput.writeChar`/`readChar`, but `DataInputOutput` implements those with 4 bytes instead of the 2 the interface specifies.

Gephi persists via `DataOutputStream`/`DataInputStream`, so **no stored data is affected** — but graphstore's own tests were round-tripping an encoding that never reaches disk. Both sides now use `writeShort`/`readUnsignedShort`, byte-identical to `DataOutputStream.writeChar`, and `DataInputOutput.writeChar`/`readChar` are fixed to honour the contract.

### Dropped `Locale` support

`Locale` is not an `AttributeUtils` supported type, so it cannot enter a graph through the public API. Tag `124` is kept reserved so it is never reused.

One edge case, accepted deliberately: `isSupported` doesn't check collection element types, so `List.of(Locale.FRENCH)` previously reached the Locale branch via `serializeList` recursion. It now fails loudly at write time, and reading such a stream fails via the new `default:`.

### Testing

Adds `testSerializationTagsAreUnique`, asserting all tag constants are distinct — confirmed to actually fail by temporarily aliasing a constant onto an existing tag value.

Full suite green: 1597 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)