### PR TITLE
Make graph attributes iteration order canonical

### DIFF
--- a/src/main/java/org/gephi/graph/impl/GraphAttributesImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphAttributesImpl.java
@@ -15,9 +15,10 @@
  */
 package org.gephi.graph.impl;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import org.gephi.graph.api.AttributeUtils;
 import org.gephi.graph.api.Interval;
 import org.gephi.graph.api.types.TimeMap;
@@ -25,13 +26,17 @@ import org.gephi.graph.impl.utils.MapDeepEquals;
 
 public class GraphAttributesImpl {
 
-    protected final Map<String, Object> attributes = new HashMap<>();
+    // A TreeMap is used so the iteration order is canonical (sorted by key).
+    // This makes serialization a pure function of the content rather than of
+    // the insertion history, which is required for byte-pinned fixtures.
+    protected final Map<String, Object> attributes = new TreeMap<>();
 
     public synchronized Set<String> getKeys() {
         return attributes.keySet();
     }
 
     public synchronized void setValue(String key, Object value) {
+        Objects.requireNonNull(key, "key");
         if (value != null) {
             checkSupportedTypes(value.getClass());
         }
@@ -39,18 +44,22 @@ public class GraphAttributesImpl {
     }
 
     public synchronized void removeValue(String key) {
+        Objects.requireNonNull(key, "key");
         attributes.remove(key);
     }
 
     public synchronized Object getValue(String key) {
+        Objects.requireNonNull(key, "key");
         return attributes.get(key);
     }
 
     public synchronized Object getValue(String key, double timestamp) {
+        Objects.requireNonNull(key, "key");
         return getValueInternal(key, timestamp);
     }
 
     public synchronized Object getValue(String key, Interval interval) {
+        Objects.requireNonNull(key, "key");
         return getValueInternal(key, interval);
     }
 
@@ -63,11 +72,13 @@ public class GraphAttributesImpl {
     }
 
     public synchronized void removeValue(String key, double timestamp) {
+        Objects.requireNonNull(key, "key");
         removeValueInternal(key, timestamp);
 
     }
 
     public synchronized void removeValue(String key, Interval interval) {
+        Objects.requireNonNull(key, "key");
         removeValueInternal(key, interval);
     }
 
@@ -83,10 +94,12 @@ public class GraphAttributesImpl {
     }
 
     public synchronized void setValue(String key, Object value, double timestamp) {
+        Objects.requireNonNull(key, "key");
         setValueInternal(key, value, timestamp);
     }
 
     public synchronized void setValue(String key, Object value, Interval interval) {
+        Objects.requireNonNull(key, "key");
         setValueInternal(key, value, interval);
     }
 


### PR DESCRIPTION
`GraphAttributesImpl` backed its map with a `HashMap`, and `Serialization.serializeGraphAttributes` iterates that map's `entrySet()` straight into the byte stream. HashMap iteration order is an implementation detail, so the serialized bytes were a function of insertion history rather than of content alone.

Switching to a `TreeMap` makes iteration sorted by key, so the same attributes always produce the same bytes regardless of the order they were set in.

`TreeMap` rejects null keys where `HashMap` accepted them, and throws NPE from deep inside the map on `get(null)` where `HashMap` returned null. Added `Objects.requireNonNull(key, "key")` to all nine public methods taking a key, so the failure is intentional and well-messaged rather than incidental.

`deepHashCode` and `deepEquals` are unchanged and remain correct — `Map.hashCode()` is specified as the order-independent sum of entry hash codes, and `deepEquals` goes through `MapDeepEquals`, which compares by key lookup.

The read path is unaffected, so previously written files still load identically. Only the ordering of newly written attribute entries changes; the format itself is untouched and `Serialization.VERSION` is not bumped.

1597 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)