### PR TITLE
Close graph-lock gaps in GraphModel.Serialization

### DIFF
--- a/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -299,48 +299,55 @@ public class Serialization {
     }
 
     public void serializeGraphStore(DataOutput out, GraphStore store) throws IOException {
-        // Configuration
-        serializeGraphStoreConfiguration(out);
+        // Hold the read lock for the whole method so the write is atomic with respect to
+        // concurrent structural mutation.
+        store.autoReadLock();
+        try {
+            // Configuration
+            serializeGraphStoreConfiguration(out);
 
-        // GraphVersion
-        serialize(out, store.version);
+            // GraphVersion
+            serialize(out, store.version);
 
-        // Edge types
-        EdgeTypeStore edgeTypeStore = store.edgeTypeStore;
-        serialize(out, edgeTypeStore);
+            // Edge types
+            EdgeTypeStore edgeTypeStore = store.edgeTypeStore;
+            serialize(out, edgeTypeStore);
 
-        // Column
-        serialize(out, store.nodeTable);
-        serialize(out, store.edgeTable);
+            // Column
+            serialize(out, store.nodeTable);
+            serialize(out, store.edgeTable);
 
-        // Time store
-        serialize(out, store.timeStore);
+            // Time store
+            serialize(out, store.timeStore);
 
-        // Factory
-        serialize(out, store.factory);
+            // Factory
+            serialize(out, store.factory);
 
-        // Atts
-        serialize(out, store.attributes);
+            // Atts
+            serialize(out, store.attributes);
 
-        // TimeFormat
-        serialize(out, store.timeFormat);
+            // TimeFormat
+            serialize(out, store.timeFormat);
 
-        // Time zone
-        serialize(out, store.timeZone);
+            // Time zone
+            serialize(out, store.timeZone);
 
-        // Nodes + Edges
-        int nodesAndEdges = store.nodeStore.size() + store.edgeStore.size();
-        serialize(out, nodesAndEdges);
+            // Nodes + Edges
+            int nodesAndEdges = store.nodeStore.size() + store.edgeStore.size();
+            serialize(out, nodesAndEdges);
 
-        for (Node node : store.nodeStore) {
-            serialize(out, node);
+            for (Node node : store.nodeStore) {
+                serialize(out, node);
+            }
+            for (Edge edge : store.edgeStore) {
+                serialize(out, edge);
+            }
+
+            // Views
+            serialize(out, store.viewStore);
+        } finally {
+            store.autoReadUnlock();
         }
-        for (Edge edge : store.edgeStore) {
-            serialize(out, edge);
-        }
-
-        // Views
-        serialize(out, store.viewStore);
     }
 
     public GraphStore deserializeGraphStore(DataInput is) throws IOException, ClassNotFoundException {

--- a/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -351,53 +351,62 @@ public class Serialization {
     }
 
     public GraphStore deserializeGraphStore(DataInput is) throws IOException, ClassNotFoundException {
-        if (!model.store.nodeStore.isEmpty()) { // TODO test other stores
-            throw new IOException("The store is not empty");
-        }
+        GraphStore store = model.store;
+        // Hold the write lock for the whole method: deserialization mutates the store directly
+        // (nodeStore.add()/edgeStore.add(), bypassing GraphStore's own auto-locked addNode()/
+        // addEdge()), so without this a concurrent reader could observe a partially-populated store.
+        store.autoWriteLock();
+        try {
+            if (!store.nodeStore.isEmpty()) { // TODO test other stores
+                throw new IOException("The store is not empty");
+            }
 
-        idMap.clear();
+            idMap.clear();
 
-        // Store Configuration
-        deserialize(is);
-
-        // Graph Version
-        GraphVersion version = (GraphVersion) deserialize(is);
-        model.store.version.nodeVersion = version.nodeVersion;
-        model.store.version.edgeVersion = version.edgeVersion;
-
-        // Edge types
-        deserialize(is);
-
-        // Columns
-        deserialize(is);
-        deserialize(is);
-
-        // Time store
-        deserialize(is);
-
-        // Factory
-        deserialize(is);
-
-        // Atts
-        GraphAttributesImpl attributes = (GraphAttributesImpl) deserialize(is);
-        model.store.attributes.setGraphAttributes(attributes);
-
-        // TimeFormat
-        deserialize(is);
-
-        // Time zone
-        deserialize(is);
-
-        // Nodes and edges
-        int nodesAndEdges = (Integer) deserialize(is);
-        for (int i = 0; i < nodesAndEdges; i++) {
+            // Store Configuration
             deserialize(is);
+
+            // Graph Version
+            GraphVersion version = (GraphVersion) deserialize(is);
+            store.version.nodeVersion = version.nodeVersion;
+            store.version.edgeVersion = version.edgeVersion;
+
+            // Edge types
+            deserialize(is);
+
+            // Columns
+            deserialize(is);
+            deserialize(is);
+
+            // Time store
+            deserialize(is);
+
+            // Factory
+            deserialize(is);
+
+            // Atts
+            GraphAttributesImpl attributes = (GraphAttributesImpl) deserialize(is);
+            store.attributes.setGraphAttributes(attributes);
+
+            // TimeFormat
+            deserialize(is);
+
+            // Time zone
+            deserialize(is);
+
+            // Nodes and edges
+            int nodesAndEdges = (Integer) deserialize(is);
+            for (int i = 0; i < nodesAndEdges; i++) {
+                deserialize(is);
+            }
+
+            // ViewStore
+            deserialize(is);
+
+            return store;
+        } finally {
+            store.autoWriteUnlock();
         }
-
-        // ViewStore
-        deserialize(is);
-
-        return model.store;
     }
 
     private void serializeNode(DataOutput out, NodeImpl node) throws IOException {

--- a/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -353,8 +353,6 @@ public class Serialization {
     public GraphStore deserializeGraphStore(DataInput is) throws IOException, ClassNotFoundException {
         GraphStore store = model.store;
         // Hold the write lock for the whole method: deserialization mutates the store directly
-        // (nodeStore.add()/edgeStore.add(), bypassing GraphStore's own auto-locked addNode()/
-        // addEdge()), so without this a concurrent reader could observe a partially-populated store.
         store.autoWriteLock();
         try {
             if (!store.nodeStore.isEmpty()) { // TODO test other stores

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -40,7 +40,9 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.ShortArrayList;
 import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
+import java.io.ByteArrayOutputStream;
 import java.io.DataOutput;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -58,6 +60,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.gephi.graph.api.Column;
 import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.GraphModel;
@@ -1563,6 +1569,164 @@ public class SerializationTest {
             int value = field.getInt(null);
             String previous = tagsByValue.put(value, name);
             Assert.assertNull(previous, "Duplicate serialization tag " + value + " shared by " + previous + " and " + name);
+        }
+    }
+
+    @Test(timeOut = 5000)
+    public void testSerializeGraphStoreHoldsReadLockForEntireDuration() throws Exception {
+        GraphModelImpl graphModel = new GraphModelImpl();
+        GraphStore graphStore = graphModel.store;
+        NodeImpl[] nodes = GraphGenerator.generateSmallNodeList();
+        graphStore.nodeStore.addAll(Arrays.asList(nodes));
+
+        CountDownLatch writeStarted = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        BlockingDataOutput blockingOutput = new BlockingDataOutput(writeStarted, proceed);
+
+        Serialization ser = new Serialization(graphModel);
+        AtomicReference<Exception> writerError = new AtomicReference<>();
+        Thread writer = new Thread(() -> {
+            try {
+                ser.serializeGraphStore(blockingOutput, graphStore);
+            } catch (Exception e) {
+                writerError.set(e);
+            }
+        });
+        writer.start();
+
+        Assert.assertTrue(writeStarted.await(2, TimeUnit.SECONDS), "serialization should have started writing");
+
+        AtomicBoolean writeLockAcquired = new AtomicBoolean(false);
+        Thread locker = new Thread(() -> {
+            graphStore.writeLock();
+            writeLockAcquired.set(true);
+            graphStore.writeUnlock();
+        });
+        locker.start();
+
+        // Give the locker thread a chance to attempt (and be blocked by) the write lock
+        Thread.sleep(300);
+        Assert.assertFalse(writeLockAcquired
+                .get(), "write lock must not be acquired while serializeGraphStore still holds the read lock");
+
+        proceed.countDown();
+        writer.join(2000);
+        locker.join(2000);
+
+        Assert.assertNull(writerError.get());
+        Assert.assertTrue(writeLockAcquired.get(), "write lock should be acquired after serialization completes");
+    }
+
+    /**
+     * A DataOutput that blocks on its very first write call until released, so tests can deterministically assert what
+     * lock state holds while a serialization call is in progress.
+     */
+    private static class BlockingDataOutput implements DataOutput {
+
+        private final DataOutputStream delegate = new DataOutputStream(new ByteArrayOutputStream());
+        private final CountDownLatch started;
+        private final CountDownLatch proceed;
+        private final AtomicBoolean first = new AtomicBoolean(true);
+
+        private BlockingDataOutput(CountDownLatch started, CountDownLatch proceed) {
+            this.started = started;
+            this.proceed = proceed;
+        }
+
+        private void beforeWrite() throws IOException {
+            if (first.compareAndSet(true, false)) {
+                started.countDown();
+                try {
+                    proceed.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                }
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            beforeWrite();
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            beforeWrite();
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            beforeWrite();
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void writeBoolean(boolean v) throws IOException {
+            beforeWrite();
+            delegate.writeBoolean(v);
+        }
+
+        @Override
+        public void writeByte(int v) throws IOException {
+            beforeWrite();
+            delegate.writeByte(v);
+        }
+
+        @Override
+        public void writeShort(int v) throws IOException {
+            beforeWrite();
+            delegate.writeShort(v);
+        }
+
+        @Override
+        public void writeChar(int v) throws IOException {
+            beforeWrite();
+            delegate.writeChar(v);
+        }
+
+        @Override
+        public void writeInt(int v) throws IOException {
+            beforeWrite();
+            delegate.writeInt(v);
+        }
+
+        @Override
+        public void writeLong(long v) throws IOException {
+            beforeWrite();
+            delegate.writeLong(v);
+        }
+
+        @Override
+        public void writeFloat(float v) throws IOException {
+            beforeWrite();
+            delegate.writeFloat(v);
+        }
+
+        @Override
+        public void writeDouble(double v) throws IOException {
+            beforeWrite();
+            delegate.writeDouble(v);
+        }
+
+        @Override
+        public void writeBytes(String s) throws IOException {
+            beforeWrite();
+            delegate.writeBytes(s);
+        }
+
+        @Override
+        public void writeChars(String s) throws IOException {
+            beforeWrite();
+            delegate.writeChars(s);
+        }
+
+        @Override
+        public void writeUTF(String s) throws IOException {
+            beforeWrite();
+            delegate.writeUTF(s);
         }
     }
 }

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -40,7 +40,10 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.ShortArrayList;
 import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -1727,6 +1730,177 @@ public class SerializationTest {
         public void writeUTF(String s) throws IOException {
             beforeWrite();
             delegate.writeUTF(s);
+        }
+    }
+
+    @Test(timeOut = 5000)
+    public void testDeserializeGraphStoreHoldsWriteLockForEntireDuration() throws Exception {
+        GraphModelImpl sourceModel = new GraphModelImpl();
+        GraphStore sourceStore = sourceModel.store;
+        NodeImpl[] nodes = GraphGenerator.generateSmallNodeList();
+        sourceStore.nodeStore.addAll(Arrays.asList(nodes));
+        DataInputOutput dio = new DataInputOutput();
+        new Serialization(sourceModel).serializeGraphStore(dio, sourceStore);
+        byte[] bytes = dio.toByteArray();
+
+        GraphModelImpl targetModel = new GraphModelImpl();
+        GraphStore targetStore = targetModel.store;
+
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        BlockingDataInput blockingInput = new BlockingDataInput(bytes, readStarted, proceed);
+
+        Serialization ser = new Serialization(targetModel);
+        AtomicReference<Exception> readerError = new AtomicReference<>();
+        Thread reader = new Thread(() -> {
+            try {
+                ser.deserializeGraphStore(blockingInput);
+            } catch (Exception e) {
+                readerError.set(e);
+            }
+        });
+        reader.start();
+
+        Assert.assertTrue(readStarted.await(2, TimeUnit.SECONDS), "deserialization should have started reading");
+
+        AtomicBoolean readLockAcquired = new AtomicBoolean(false);
+        Thread locker = new Thread(() -> {
+            targetStore.readLock();
+            readLockAcquired.set(true);
+            targetStore.readUnlock();
+        });
+        locker.start();
+
+        // Give the locker thread a chance to attempt (and be blocked by) the read lock
+        Thread.sleep(300);
+        Assert.assertFalse(readLockAcquired
+                .get(), "read lock must not be acquired while deserializeGraphStore still holds the write lock");
+
+        proceed.countDown();
+        reader.join(2000);
+        locker.join(2000);
+
+        Assert.assertNull(readerError.get());
+        Assert.assertTrue(readLockAcquired.get(), "read lock should be acquired after deserialization completes");
+    }
+
+    /**
+     * A DataInput that blocks on its very first read call until released, so tests can deterministically assert what
+     * lock state holds while a deserialization call is in progress.
+     */
+    private static class BlockingDataInput implements DataInput {
+
+        private final DataInputStream delegate;
+        private final CountDownLatch started;
+        private final CountDownLatch proceed;
+        private final AtomicBoolean first = new AtomicBoolean(true);
+
+        private BlockingDataInput(byte[] bytes, CountDownLatch started, CountDownLatch proceed) {
+            this.delegate = new DataInputStream(new ByteArrayInputStream(bytes));
+            this.started = started;
+            this.proceed = proceed;
+        }
+
+        private void beforeRead() throws IOException {
+            if (first.compareAndSet(true, false)) {
+                started.countDown();
+                try {
+                    proceed.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                }
+            }
+        }
+
+        @Override
+        public void readFully(byte[] b) throws IOException {
+            beforeRead();
+            delegate.readFully(b);
+        }
+
+        @Override
+        public void readFully(byte[] b, int off, int len) throws IOException {
+            beforeRead();
+            delegate.readFully(b, off, len);
+        }
+
+        @Override
+        public int skipBytes(int n) throws IOException {
+            beforeRead();
+            return delegate.skipBytes(n);
+        }
+
+        @Override
+        public boolean readBoolean() throws IOException {
+            beforeRead();
+            return delegate.readBoolean();
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            beforeRead();
+            return delegate.readByte();
+        }
+
+        @Override
+        public int readUnsignedByte() throws IOException {
+            beforeRead();
+            return delegate.readUnsignedByte();
+        }
+
+        @Override
+        public short readShort() throws IOException {
+            beforeRead();
+            return delegate.readShort();
+        }
+
+        @Override
+        public int readUnsignedShort() throws IOException {
+            beforeRead();
+            return delegate.readUnsignedShort();
+        }
+
+        @Override
+        public char readChar() throws IOException {
+            beforeRead();
+            return delegate.readChar();
+        }
+
+        @Override
+        public int readInt() throws IOException {
+            beforeRead();
+            return delegate.readInt();
+        }
+
+        @Override
+        public long readLong() throws IOException {
+            beforeRead();
+            return delegate.readLong();
+        }
+
+        @Override
+        public float readFloat() throws IOException {
+            beforeRead();
+            return delegate.readFloat();
+        }
+
+        @Override
+        public double readDouble() throws IOException {
+            beforeRead();
+            return delegate.readDouble();
+        }
+
+        @Override
+        public String readLine() throws IOException {
+            beforeRead();
+            return delegate.readLine();
+        }
+
+        @Override
+        public String readUTF() throws IOException {
+            beforeRead();
+            return delegate.readUTF();
         }
     }
 }


### PR DESCRIPTION
## Summary
- `serializeGraphStore()` previously relied on incidental locking from `NodeStore`/`EdgeStore` iterators, which only cover the node loop and the edge loop individually and drop the lock between them (and never covered the configuration/columns/time-store/views sections at all). It now holds the read lock for the entire method, making a serialized snapshot atomic against concurrent structural mutation.
- `deserializeGraphStore()` had no lock coverage at all — it writes directly into `NodeStore`/`EdgeStore`, bypassing `GraphStore`'s own auto-locked `addNode()`/`addEdge()`. It now holds the write lock for the entire method.

Both changes are internal to `Serialization`; no public API or on-disk format changes.

## Test plan
- [x] Added `testSerializeGraphStoreHoldsReadLockForEntireDuration`: uses a `DataOutput` that blocks on its first write so a concurrent `writeLock()` attempt can be asserted to block until serialization completes. Verified it fails on the pre-fix code and passes after.
- [x] Added `testDeserializeGraphStoreHoldsWriteLockForEntireDuration`: mirrors the above with a blocking `DataInput` and a concurrent `readLock()` attempt. Verified red/green the same way.
- [x] Full suite passes (1638 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)