### PR TITLE
Fail fast on unsupported serialization format versions

### DIFF
--- a/src/main/java/org/gephi/graph/api/UnsupportedFormatVersionException.java
+++ b/src/main/java/org/gephi/graph/api/UnsupportedFormatVersionException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2013 Gephi Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gephi.graph.api;
+
+import java.io.IOException;
+
+/**
+ * Thrown when reading a serialized graph model written by a newer, incompatible version of graphstore than the one
+ * doing the reading.
+ * <p>
+ * Extends {@link IOException} so it is caught by existing code that only handles I/O errors, while callers that want to
+ * report a specific, localized message can catch this type directly and use {@link #getFileVersion()} and
+ * {@link #getMaxSupportedVersion()} instead of parsing the message.
+ */
+public class UnsupportedFormatVersionException extends IOException {
+
+    private final float fileVersion;
+    private final float maxSupportedVersion;
+
+    public UnsupportedFormatVersionException(float fileVersion, float maxSupportedVersion) {
+        super("Unsupported serialization format version: " + fileVersion + ". This file was written by a newer version of graphstore than this library supports (up to " + maxSupportedVersion + "). Please upgrade graphstore to read this file.");
+        this.fileVersion = fileVersion;
+        this.maxSupportedVersion = maxSupportedVersion;
+    }
+
+    /**
+     * Returns the format version the file was written with.
+     *
+     * @return file format version
+     */
+    public float getFileVersion() {
+        return fileVersion;
+    }
+
+    /**
+     * Returns the highest format version this version of graphstore can read.
+     *
+     * @return max supported format version
+     */
+    public float getMaxSupportedVersion() {
+        return maxSupportedVersion;
+    }
+}

--- a/src/main/java/org/gephi/graph/impl/Serialization.java
+++ b/src/main/java/org/gephi/graph/impl/Serialization.java
@@ -66,6 +66,7 @@ import org.gephi.graph.api.Node;
 import org.gephi.graph.api.Origin;
 import org.gephi.graph.api.TimeFormat;
 import org.gephi.graph.api.TimeRepresentation;
+import org.gephi.graph.api.UnsupportedFormatVersionException;
 import org.gephi.graph.api.types.IntervalBooleanMap;
 import org.gephi.graph.api.types.IntervalByteMap;
 import org.gephi.graph.api.types.IntervalCharMap;
@@ -243,6 +244,7 @@ public class Serialization {
 
     public GraphModelImpl deserializeGraphModel(DataInput is) throws IOException, ClassNotFoundException {
         readVersion = (Float) deserialize(is);
+        checkVersionSupported();
         ConfigurationImpl config = (ConfigurationImpl) deserialize(is);
         model = new GraphModelImpl(config.toConfiguration());
         deserialize(is);
@@ -252,10 +254,19 @@ public class Serialization {
     public GraphModelImpl deserializeGraphModel(DataInput is, GraphModel graphModel) throws IOException, ClassNotFoundException {
         model = (GraphModelImpl) graphModel;
         readVersion = (Float) deserialize(is);
+        checkVersionSupported();
         ConfigurationImpl config = (ConfigurationImpl) deserialize(is);
         verifyCompatibility(config, model.configuration);
         deserialize(is);
         return model;
+    }
+
+    // Fails fast, before any store state is touched, instead of letting a later unrecognized type
+    // tag surface as a confusing "Unknown serialization type tag" mid-deserialization.
+    private void checkVersionSupported() throws UnsupportedFormatVersionException {
+        if (readVersion > VERSION) {
+            throw new UnsupportedFormatVersionException(readVersion, VERSION);
+        }
     }
 
     private void verifyCompatibility(ConfigurationImpl readConfig, ConfigurationImpl modelConfig) {
@@ -292,6 +303,7 @@ public class Serialization {
 
     public GraphModelImpl deserializeGraphModelWithoutVersionPrefix(DataInput is, float version) throws IOException, ClassNotFoundException {
         readVersion = version;
+        checkVersionSupported();
         ConfigurationImpl config = (ConfigurationImpl) deserialize(is);
         model = new GraphModelImpl(config.toConfiguration());
         deserialize(is);

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -86,6 +86,7 @@ import org.gephi.graph.api.types.TimestampStringMap;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Interval;
 import org.gephi.graph.api.TimeRepresentation;
+import org.gephi.graph.api.UnsupportedFormatVersionException;
 import org.gephi.graph.api.types.IntervalBooleanMap;
 import org.gephi.graph.api.types.IntervalByteMap;
 import org.gephi.graph.api.types.IntervalCharMap;
@@ -1509,6 +1510,53 @@ public class SerializationTest {
         ser = new Serialization();
         GraphModelImpl read = ser.deserializeGraphModelWithoutVersionPrefix(dio.reset(bytes), Serialization.VERSION);
         Assert.assertTrue(read.deepEquals(gm));
+    }
+
+    @Test
+    public void testDeserializeGraphModelRejectsNewerVersion() throws Exception {
+        GraphModelImpl gm = GraphGenerator.generateSmallGraphStore().graphModel;
+        Serialization ser = new Serialization(gm) {
+            @Override
+            public void serializeGraphModel(DataOutput out, GraphModelImpl model) throws IOException {
+                this.model = model;
+                serialize(out, VERSION + 1f);
+                serialize(out, model.configuration);
+                serialize(out, model.store);
+            }
+        };
+
+        DataInputOutput dio = new DataInputOutput();
+        ser.serializeGraphModel(dio, gm);
+        byte[] bytes = dio.toByteArray();
+
+        UnsupportedFormatVersionException ex = Assert
+                .expectThrows(UnsupportedFormatVersionException.class, () -> new Serialization()
+                        .deserializeGraphModel(dio.reset(bytes)));
+        Assert.assertEquals(ex.getFileVersion(), Serialization.VERSION + 1f);
+        Assert.assertEquals(ex.getMaxSupportedVersion(), Serialization.VERSION);
+    }
+
+    @Test
+    public void testDeserializeGraphModelWithoutVersionPrefixRejectsNewerVersion() throws Exception {
+        GraphModelImpl gm = GraphGenerator.generateSmallGraphStore().graphModel;
+        Serialization ser = new Serialization(gm) {
+            @Override
+            public void serializeGraphModel(DataOutput out, GraphModelImpl model) throws IOException {
+                this.model = model;
+                serialize(out, model.configuration);
+                serialize(out, model.store);
+            }
+        };
+
+        DataInputOutput dio = new DataInputOutput();
+        ser.serializeGraphModel(dio, gm);
+        byte[] bytes = dio.toByteArray();
+
+        UnsupportedFormatVersionException ex = Assert
+                .expectThrows(UnsupportedFormatVersionException.class, () -> new Serialization()
+                        .deserializeGraphModelWithoutVersionPrefix(dio.reset(bytes), Serialization.VERSION + 1f));
+        Assert.assertEquals(ex.getFileVersion(), Serialization.VERSION + 1f);
+        Assert.assertEquals(ex.getMaxSupportedVersion(), Serialization.VERSION);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Reading a file written by a newer, incompatible graphstore version currently fails deep inside `deserialize()`'s tag switch with a generic "Unknown serialization type tag" error, only after the store has already been locked/partially mutated.
- `checkVersionSupported()` now runs immediately after `readVersion` is read in all three `deserializeGraphModel*` entry points, before any config/store bytes are touched, and raises a new `UnsupportedFormatVersionException` (extends `IOException`, so no signature changes) when the file's version exceeds what this build supports.
- The new exception exposes `getFileVersion()`/`getMaxSupportedVersion()` so consumers like Gephi can catch it specifically and build a clean, localized error message instead of parsing generic `IOException` text.
- `Serialization.VERSION` stays at `0.5f` for now — no format change accompanies this PR — so the check is currently a no-op and only activates the next time `VERSION` is bumped for an actual format change.

## Test plan
- [x] `mvn -o test -Dtest=SerializationTest,SerializationCompatibilityTest`
- [x] `mvn -o test` (full suite)