### PR TITLE
Fix generateLargeGraphStore() building edges over detached nodes

### DIFF
--- a/src/test/java/org/gephi/graph/impl/GraphGenerator.java
+++ b/src/test/java/org/gephi/graph/impl/GraphGenerator.java
@@ -551,11 +551,6 @@ public class GraphGenerator {
 
         NodeImpl[] nodes = generateLargeNodeList();
         graphStore.addAllNodes(Arrays.asList(nodes));
-        // Build edges against the real, inserted nodeStore rather than generateLargeEdgeList()'s own
-        // throwaway node population (which is sized and constructed independently of `nodes` above) -
-        // otherwise edge.source/target reference detached node objects that merely happen to share a
-        // storeId with a real node, which falls apart the moment a node is removed (its cascade-delete
-        // walks the real node's own adjacency links, which were never wired to these edges).
         EdgeImpl[] edges = generateEdgeList(graphStore.nodeStore, GraphStoreConfiguration.EDGESTORE_BLOCK_SIZE * 3 + (int) (GraphStoreConfiguration.EDGESTORE_BLOCK_SIZE / 3.0), 0, true, true, false);
         graphStore.addAllEdges(Arrays.asList(edges));
         return graphStore;

--- a/src/test/java/org/gephi/graph/impl/GraphGenerator.java
+++ b/src/test/java/org/gephi/graph/impl/GraphGenerator.java
@@ -551,7 +551,12 @@ public class GraphGenerator {
 
         NodeImpl[] nodes = generateLargeNodeList();
         graphStore.addAllNodes(Arrays.asList(nodes));
-        EdgeImpl[] edges = generateLargeEdgeList();
+        // Build edges against the real, inserted nodeStore rather than generateLargeEdgeList()'s own
+        // throwaway node population (which is sized and constructed independently of `nodes` above) -
+        // otherwise edge.source/target reference detached node objects that merely happen to share a
+        // storeId with a real node, which falls apart the moment a node is removed (its cascade-delete
+        // walks the real node's own adjacency links, which were never wired to these edges).
+        EdgeImpl[] edges = generateEdgeList(graphStore.nodeStore, GraphStoreConfiguration.EDGESTORE_BLOCK_SIZE * 3 + (int) (GraphStoreConfiguration.EDGESTORE_BLOCK_SIZE / 3.0), 0, true, true, false);
         graphStore.addAllEdges(Arrays.asList(edges));
         return graphStore;
     }

--- a/src/test/java/org/gephi/graph/impl/GraphGeneratorTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphGeneratorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2013 Gephi Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gephi.graph.impl;
+
+import org.gephi.graph.api.Edge;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class GraphGeneratorTest {
+
+    @Test
+    public void testGenerateLargeGraphStoreEdgesReferenceRealNodes() {
+        GraphStore graphStore = GraphGenerator.generateLargeGraphStore();
+
+        // Edges must reference the same node objects registered in the store's own nodeStore, not just
+        // objects that happen to carry a matching storeId - otherwise removeNode()'s cascade-edge-removal
+        // (which walks the real node's own adjacency links) silently fails to find and remove them.
+        for (Edge edge : graphStore.edgeStore) {
+            EdgeImpl e = (EdgeImpl) edge;
+            Assert.assertSame(graphStore.nodeStore.get(e.source.storeId), e.source);
+            Assert.assertSame(graphStore.nodeStore.get(e.target.storeId), e.target);
+        }
+    }
+}

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -1951,37 +1951,4 @@ public class SerializationTest {
             return delegate.readUTF();
         }
     }
-
-    @Test
-    public void testSerializeAndDeserializeMultiBlockGraphAfterRemovalsRoundTrips() throws Exception {
-        // Regression test for a GraphGenerator.generateLargeGraphStore() bug: its edges used to
-        // reference a throwaway, independently-sized node population instead of the real nodeStore, so
-        // removeNode()'s cascade-edge-removal (which walks the real node's own adjacency links) could
-        // silently leave dangling edges behind whenever a referenced node was removed. That only
-        // surfaced once something both spanned multiple storage blocks and had elements removed
-        // afterward, which serialization round-tripping does here.
-        GraphStore graphStore = GraphGenerator.generateLargeGraphStore();
-
-        NodeImpl[] nodes = graphStore.nodeStore.toArray();
-        for (int i = 0; i < nodes.length; i += 11) {
-            graphStore.removeNode(nodes[i]);
-        }
-        EdgeImpl[] edges = graphStore.edgeStore.toArray();
-        for (int i = 0; i < edges.length; i += 5) {
-            graphStore.removeEdge(edges[i]);
-        }
-
-        GraphModelImpl graphModel = new GraphModelImpl();
-        Serialization ser = new Serialization(graphModel);
-        DataInputOutput dio = new DataInputOutput();
-        ser.serializeGraphStore(dio, graphStore);
-        byte[] bytes = dio.toByteArray();
-
-        GraphModelImpl graphModel2 = new GraphModelImpl();
-        Serialization ser2 = new Serialization(graphModel2);
-        GraphStore deserialized = ser2.deserializeGraphStore(dio.reset(bytes));
-
-        Assert.assertTrue(graphStore.nodeStore.deepEquals(deserialized.nodeStore));
-        Assert.assertTrue(graphStore.edgeStore.deepEquals(deserialized.edgeStore));
-    }
 }

--- a/src/test/java/org/gephi/graph/impl/SerializationTest.java
+++ b/src/test/java/org/gephi/graph/impl/SerializationTest.java
@@ -1951,4 +1951,37 @@ public class SerializationTest {
             return delegate.readUTF();
         }
     }
+
+    @Test
+    public void testSerializeAndDeserializeMultiBlockGraphAfterRemovalsRoundTrips() throws Exception {
+        // Regression test for a GraphGenerator.generateLargeGraphStore() bug: its edges used to
+        // reference a throwaway, independently-sized node population instead of the real nodeStore, so
+        // removeNode()'s cascade-edge-removal (which walks the real node's own adjacency links) could
+        // silently leave dangling edges behind whenever a referenced node was removed. That only
+        // surfaced once something both spanned multiple storage blocks and had elements removed
+        // afterward, which serialization round-tripping does here.
+        GraphStore graphStore = GraphGenerator.generateLargeGraphStore();
+
+        NodeImpl[] nodes = graphStore.nodeStore.toArray();
+        for (int i = 0; i < nodes.length; i += 11) {
+            graphStore.removeNode(nodes[i]);
+        }
+        EdgeImpl[] edges = graphStore.edgeStore.toArray();
+        for (int i = 0; i < edges.length; i += 5) {
+            graphStore.removeEdge(edges[i]);
+        }
+
+        GraphModelImpl graphModel = new GraphModelImpl();
+        Serialization ser = new Serialization(graphModel);
+        DataInputOutput dio = new DataInputOutput();
+        ser.serializeGraphStore(dio, graphStore);
+        byte[] bytes = dio.toByteArray();
+
+        GraphModelImpl graphModel2 = new GraphModelImpl();
+        Serialization ser2 = new Serialization(graphModel2);
+        GraphStore deserialized = ser2.deserializeGraphStore(dio.reset(bytes));
+
+        Assert.assertTrue(graphStore.nodeStore.deepEquals(deserialized.nodeStore));
+        Assert.assertTrue(graphStore.edgeStore.deepEquals(deserialized.edgeStore));
+    }
 }


### PR DESCRIPTION
## Summary
Root-caused the "pre-existing bug" flagged in #291: it's not a `Serialization`/`GraphStore` correctness issue, it's a test-helper construction flaw.

`GraphGenerator.generateLargeGraphStore()` built its node list via `generateLargeNodeList()` and its edge list via `generateLargeEdgeList()` independently. The latter internally creates its **own**, differently-sized, throwaway `NodeStore` to source edge endpoints from — so `edge.source`/`edge.target` never actually pointed at the nodes inserted into the real `GraphStore`. They only lined up *numerically* (same `storeId` value) by coincidence of both being simple sequential-counter allocations, which is why everything looked fine as long as no node was ever removed afterward.

Confirmed directly: `graphStore.nodeStore.get(edge.source.storeId) != edge.source` for every edge, before this fix.

Once a referenced node *is* removed, `GraphStore.removeNode()`'s cascade (which walks the real node's own in/out adjacency links to find and remove incident edges) finds nothing to remove — because those links were never wired to the edges that "coincidentally" reference that `storeId` — leaving a dangling edge behind. That only became visible once something both spanned multiple storage blocks and had elements removed afterward, which is exactly what came up while testing #291.

**Fix**: build edges via `generateEdgeList(graphStore.nodeStore, ...)` so they reference the real, inserted nodes. `generateLargeNodeList()`/`generateLargeEdgeList()` are untouched (other tests use them independently, as standalone lists, not paired) — and `generateLargeGraphStore()` itself was unused anywhere in the suite before this session's new tests, so nothing depended on the old behavior.

## Test plan
- [x] New regression test: `generateLargeGraphStore()` + scattered node/edge removal (multi-block, matches the scenario that surfaced this) + full serialize/deserialize round-trip, asserting `deepEquals`. Fails red on the old generator, passes green with the fix.
- [x] Full suite green (1641 tests), run 2x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)