### PR TITLE
Fix unquoted array string values truncated at parenthesis

### DIFF
--- a/src/main/java/org/gephi/graph/impl/ArraysParser.java
+++ b/src/main/java/org/gephi/graph/impl/ArraysParser.java
@@ -17,9 +17,7 @@ package org.gephi.graph.impl;
 
 import static org.gephi.graph.impl.FormattingAndParsingUtils.COMMA;
 import static org.gephi.graph.impl.FormattingAndParsingUtils.EMPTY_VALUE;
-import static org.gephi.graph.impl.FormattingAndParsingUtils.LEFT_BOUND_BRACKET;
 import static org.gephi.graph.impl.FormattingAndParsingUtils.LEFT_BOUND_SQUARE_BRACKET;
-import static org.gephi.graph.impl.FormattingAndParsingUtils.RIGHT_BOUND_BRACKET;
 import static org.gephi.graph.impl.FormattingAndParsingUtils.RIGHT_BOUND_SQUARE_BRACKET;
 
 import java.io.IOException;
@@ -83,8 +81,6 @@ public final class ArraysParser {
                 c = (char) r;
                 switch (c) {
                     case RIGHT_BOUND_SQUARE_BRACKET:
-                    case RIGHT_BOUND_BRACKET:
-                    case LEFT_BOUND_BRACKET:
                     case LEFT_BOUND_SQUARE_BRACKET:
                     case ' ':
                     case '\t':
@@ -101,7 +97,7 @@ public final class ArraysParser {
                     default:
                         reader.skip(-1);// Go backwards 1 position, for reading
                                         // start of value
-                        String value = FormattingAndParsingUtils.parseValue(reader);
+                        String value = FormattingAndParsingUtils.parseValue(reader, false);
                         if (value.equals("null")) {
                             value = null;// Special null value only when not in
                                          // literal parsing mode

--- a/src/main/java/org/gephi/graph/impl/FormattingAndParsingUtils.java
+++ b/src/main/java/org/gephi/graph/impl/FormattingAndParsingUtils.java
@@ -126,20 +126,40 @@ public final class FormattingAndParsingUtils {
     }
 
     /**
-     * Parses a value until end is detected either by a comma or a bounds closing character.
+     * Parses a value until end is detected either by a comma or a bounds closing character. Both {@code )} and
+     * {@code ]} are treated as a closing bound, since this is used for parsing interval and timestamp bounds which can
+     * be opened/closed with either bracket type.
      *
      * @param reader Input reader
      * @return Parsed value
      * @throws IOException Unexpected read error
      */
     protected static String parseValue(StringReader reader) throws IOException {
+        return parseValue(reader, true);
+    }
+
+    /**
+     * Parses a value until end is detected either by a comma or a bounds closing character.
+     *
+     * @param reader Input reader
+     * @param roundBracketIsClosingBound Whether {@code )} should be treated as a closing bound character in addition to
+     *        {@code ]}. This should be disabled for grammars, such as plain arrays, where {@code (} and {@code )} have
+     *        no structural meaning and can be part of an unquoted value.
+     * @return Parsed value
+     * @throws IOException Unexpected read error
+     */
+    protected static String parseValue(StringReader reader, boolean roundBracketIsClosingBound) throws IOException {
         StringBuilder sb = new StringBuilder();
         int r;
         char c;
         while ((r = reader.read()) != -1) {
             c = (char) r;
+            if (roundBracketIsClosingBound && c == RIGHT_BOUND_BRACKET) {
+                reader.skip(-1);// Go backwards 1 position, for detecting end
+                                // of bounds
+                return sb.toString().trim();
+            }
             switch (c) {
-                case RIGHT_BOUND_BRACKET:
                 case RIGHT_BOUND_SQUARE_BRACKET:
                     reader.skip(-1);// Go backwards 1 position, for detecting
                                     // end of bounds

--- a/src/test/java/org/gephi/graph/impl/ArraysParserTest.java
+++ b/src/test/java/org/gephi/graph/impl/ArraysParserTest.java
@@ -47,6 +47,15 @@ public class ArraysParserTest {
     }
 
     @Test
+    public void testParseStringWithParenthesis() {
+        String[] a1 = ArraysParser.parseArray(String[].class, "[Foo,Bar(Foo)]");
+        String[] a2 = ArraysParser.parseArray(String[].class, "[(Foo), Bar(Foo), Baz)(]");
+
+        Assert.assertEquals(new String[] { "Foo", "Bar(Foo)" }, a1);
+        Assert.assertEquals(new String[] { "(Foo)", "Bar(Foo)", "Baz)(" }, a2);
+    }
+
+    @Test
     public void testParseCharacter() {
         Character[] a1 = ArraysParser.parseArray(Character[].class, "[a, b, c, 2, 9]");
         char[] a2 = (char[]) ArraysParser.parseArrayAsPrimitiveArray(Character[].class, "[a, b, c, 2, 9]");


### PR DESCRIPTION
## Summary
- `FormattingAndParsingUtils.parseValue()` treats `)` the same as `]` as an "end of value" delimiter, a rule meant for interval bounds like `(1,2)`. `ArraysParser` reused this same method for plain array/string elements, where `(`/`)` have no structural meaning, so a literal `)` inside an unquoted array element got misread as the end of the value and silently dropped.
- Example: parsing the liststring `[Foo,Bar(Foo)]` produced `["Foo", "Bar(Foo"]` instead of `["Foo", "Bar(Foo)"]`.
- Fix: `parseValue` now takes a flag controlling whether `)` counts as a closing bound (kept `true` for `IntervalsParser`/`TimestampsParser`, which need it); `ArraysParser` passes `false` and no longer treats `(`/`)` as ignorable structural characters, so they're preserved as literal content of unquoted values.

Fixes gephi/gephi#2989

## Test plan
- Added `ArraysParserTest.testParseStringWithParenthesis` covering the reported case plus leading/trailing/unbalanced parens.
- `mvn test` passes for the full suite.