### PR TITLE
Fix incorrect default value in enableParallelEdgesSameType javadoc

### DIFF
--- a/src/main/java/org/gephi/graph/api/Configuration.java
+++ b/src/main/java/org/gephi/graph/api/Configuration.java
@@ -408,7 +408,7 @@ public class Configuration {
          * <p>
          * If disabled, only a single edge of a given type can exist between two nodes.
          * <p>
-         * Default is <code>false</code>.
+         * Default is <code>true</code>.
          *
          * @param enableParallelEdgesSameType enable parallel edges of the same type
          * @return this builder


### PR DESCRIPTION
## Summary
- The javadoc for `Configuration.Builder.enableParallelEdgesSameType()` stated the default is `false`, but `GraphStoreConfiguration.DEFAULT_ENABLE_PARALLEL_EDGES_SAME_TYPE` is actually `true`, confirmed by `ConfigurationImpl`'s default constructor and existing tests (`GraphStoreTest.testAddEdgeWithSameType()`).

## Test plan
- [x] Docs-only change, no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)