### PR TITLE
Add a dedicated monitor for graph observer list access

### DIFF
--- a/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphModelImpl.java
@@ -377,6 +377,9 @@ public class GraphModelImpl implements GraphModel {
 
     @Override
     public GraphObserver createGraphObserver(Graph graph, boolean withGraphDiff) {
+        // The graph write lock makes the view-existence check and the registration atomic with
+        // respect to view destruction. Registration itself is guarded by the observers monitor,
+        // always acquired inside the graph lock.
         store.autoWriteLock();
         try {
             if (graph.getView().isMainView()) {
@@ -456,6 +459,8 @@ public class GraphModelImpl implements GraphModel {
     public void destroyGraphObserver(GraphObserver observer) {
         checkGraphObserver(observer);
 
+        // See createGraphObserver: the graph lock keeps this atomic with view destruction, which
+        // also destroys the view's observers.
         store.autoWriteLock();
         try {
             if (observer.getGraph().getView().isMainView()) {

--- a/src/main/java/org/gephi/graph/impl/GraphObserverImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphObserverImpl.java
@@ -37,7 +37,7 @@ public class GraphObserverImpl implements GraphObserver {
     // Version
     protected int nodeVersion = Integer.MIN_VALUE;
     protected int edgeVersion = Integer.MIN_VALUE;
-    protected boolean destroyed;
+    protected volatile boolean destroyed;
     protected boolean newObserver = true;
     // Cache
     protected GraphDiffImpl graphDiff;

--- a/src/main/java/org/gephi/graph/impl/GraphStore.java
+++ b/src/main/java/org/gephi/graph/impl/GraphStore.java
@@ -839,8 +839,13 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
         }
 
         if (observers != null) {
+            // Constructed outside the monitor: the constructor takes the graph read lock and
+            // acquiring it under the monitor would invert the lock order used elsewhere
             GraphObserverImpl observer = new GraphObserverImpl(this, version, graph, withDiff);
-            observers.add(observer);
+            // The list also has its own monitor, so it stays safe even if auto-locking is disabled
+            synchronized (observers) {
+                observers.add(observer);
+            }
 
             return observer;
         }
@@ -852,8 +857,10 @@ public class GraphStore implements DirectedGraph, DirectedSubgraph {
             if (observer.graph.getView() != mainGraphView) {
                 throw new RuntimeException("This graph doesn't belong to this store");
             }
-            observers.remove(observer);
-            observer.destroyObserver();
+            synchronized (observers) {
+                observers.remove(observer);
+                observer.destroyObserver();
+            }
         }
     }
 

--- a/src/main/java/org/gephi/graph/impl/GraphVersion.java
+++ b/src/main/java/org/gephi/graph/impl/GraphVersion.java
@@ -58,15 +58,20 @@ public class GraphVersion {
             if (graph.getView().isMainView()) {
                 GraphStore graphStore = (GraphStore) graph;
                 if (graphStore.observers != null) {
-                    for (GraphObserverImpl observer : graphStore.observers) {
-                        observer.resetNodeVersion();
+                    // Same monitor used by create/destroy, so it stays safe even if auto-locking is disabled
+                    synchronized (graphStore.observers) {
+                        for (GraphObserverImpl observer : graphStore.observers) {
+                            observer.resetNodeVersion();
+                        }
                     }
                 }
             } else {
                 GraphViewImpl view = (GraphViewImpl) graph.getView();
                 if (view.observers != null) {
-                    for (GraphObserverImpl observer : view.observers) {
-                        observer.resetNodeVersion();
+                    synchronized (view.observers) {
+                        for (GraphObserverImpl observer : view.observers) {
+                            observer.resetNodeVersion();
+                        }
                     }
                 }
             }
@@ -78,15 +83,20 @@ public class GraphVersion {
             if (graph.getView().isMainView()) {
                 GraphStore graphStore = (GraphStore) graph;
                 if (graphStore.observers != null) {
-                    for (GraphObserverImpl observer : graphStore.observers) {
-                        observer.resetEdgeVersion();
+                    // Same monitor used by create/destroy, so it stays safe even if auto-locking is disabled
+                    synchronized (graphStore.observers) {
+                        for (GraphObserverImpl observer : graphStore.observers) {
+                            observer.resetEdgeVersion();
+                        }
                     }
                 }
             } else {
                 GraphViewImpl view = (GraphViewImpl) graph.getView();
                 if (view.observers != null) {
-                    for (GraphObserverImpl observer : view.observers) {
-                        observer.resetEdgeVersion();
+                    synchronized (view.observers) {
+                        for (GraphObserverImpl observer : view.observers) {
+                            observer.resetEdgeVersion();
+                        }
                     }
                 }
             }

--- a/src/main/java/org/gephi/graph/impl/GraphViewImpl.java
+++ b/src/main/java/org/gephi/graph/impl/GraphViewImpl.java
@@ -982,8 +982,13 @@ public class GraphViewImpl implements GraphView {
 
     protected GraphObserverImpl createGraphObserver(Graph graph, boolean withDiff) {
         if (observers != null) {
+            // Constructed outside the monitor: the constructor takes the graph read lock and
+            // acquiring it under the monitor would invert the lock order used elsewhere
             GraphObserverImpl observer = new GraphObserverImpl(graphStore, version, graph, withDiff);
-            observers.add(observer);
+            // The list also has its own monitor, so it stays safe even if auto-locking is disabled
+            synchronized (observers) {
+                observers.add(observer);
+            }
 
             return observer;
         }
@@ -992,17 +997,21 @@ public class GraphViewImpl implements GraphView {
 
     protected void destroyGraphObserver(GraphObserverImpl observer) {
         if (observers != null) {
-            observers.remove(observer);
-            observer.destroyObserver();
+            synchronized (observers) {
+                observers.remove(observer);
+                observer.destroyObserver();
+            }
         }
     }
 
     protected void destroyAllObservers() {
         if (observers != null) {
-            for (GraphObserverImpl graphObserverImpl : observers) {
-                graphObserverImpl.destroyObserver();
+            synchronized (observers) {
+                for (GraphObserverImpl graphObserverImpl : observers) {
+                    graphObserverImpl.destroyObserver();
+                }
+                observers.clear();
             }
-            observers.clear();
         }
     }
 

--- a/src/test/java/org/gephi/graph/impl/GraphObserverTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphObserverTest.java
@@ -15,10 +15,21 @@
  */
 package org.gephi.graph.impl;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.EdgeIterable;
+import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphDiff;
+import org.gephi.graph.api.GraphObserver;
 import org.gephi.graph.api.Node;
 import org.gephi.graph.api.NodeIterable;
 import org.testng.Assert;
@@ -488,5 +499,109 @@ public class GraphObserverTest {
 
         Assert.assertEquals(edgeVersion, Integer.MIN_VALUE + 1);
         Assert.assertEquals(graphObserver.edgeVersion, Integer.MIN_VALUE);
+    }
+
+    @Test
+    public void testConcurrentCreateAndDestroyGraphObserver() throws Exception {
+        final int threadCount = 4;
+        final int iterations = 200;
+
+        final GraphStore store = GraphGenerator.generateSmallGraphStore();
+        final GraphModelImpl graphModel = store.graphModel;
+        final AtomicBoolean mutating = new AtomicBoolean(true);
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount + 1);
+        try {
+            // Forces the version overflow path, which iterates the observers while other threads
+            // register and unregister
+            Future<?> mutator = executor.submit(() -> {
+                barrier.await();
+                Node node = store.factory.newNode("concurrent-observer-test");
+                while (mutating.get()) {
+                    store.autoWriteLock();
+                    try {
+                        store.version.nodeVersion = Integer.MAX_VALUE - 1;
+                        store.version.edgeVersion = Integer.MAX_VALUE - 1;
+                        store.addNode(node);
+                        store.removeNode(node);
+                    } finally {
+                        store.autoWriteUnlock();
+                    }
+                }
+                return null;
+            });
+
+            List<Future<?>> tasks = new ArrayList<>();
+            for (int t = 0; t < threadCount; t++) {
+                tasks.add(executor.submit((Callable<Void>) () -> {
+                    barrier.await();
+                    for (int i = 0; i < iterations; i++) {
+                        GraphObserver observer = graphModel.createGraphObserver(store, i % 2 == 0);
+                        observer.hasGraphChanged();
+                        observer.destroy();
+                        Assert.assertTrue(observer.isDestroyed());
+                    }
+                    return null;
+                }));
+            }
+
+            for (Future<?> task : tasks) {
+                task.get(60, TimeUnit.SECONDS);
+            }
+            mutating.set(false);
+            mutator.get(60, TimeUnit.SECONDS);
+        } finally {
+            mutating.set(false);
+            executor.shutdownNow();
+        }
+
+        Assert.assertTrue(store.observers.isEmpty());
+    }
+
+    @Test
+    public void testConcurrentCreateGraphObserverAndDestroyView() throws Exception {
+        final int rounds = 200;
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (int round = 0; round < rounds; round++) {
+                final GraphStore store = GraphGenerator.generateTinyGraphStore();
+                final GraphModelImpl graphModel = store.graphModel;
+                final GraphViewImpl view = (GraphViewImpl) graphModel.createView();
+                final Graph viewGraph = graphModel.getGraph(view);
+                final CyclicBarrier barrier = new CyclicBarrier(2);
+
+                Future<GraphObserver> creation = executor.submit(() -> {
+                    barrier.await();
+                    try {
+                        return graphModel.createGraphObserver(viewGraph, true);
+                    } catch (IllegalArgumentException e) {
+                        // The view was destroyed first
+                        return null;
+                    }
+                });
+                Future<?> destruction = executor.submit((Callable<Void>) () -> {
+                    barrier.await();
+                    graphModel.destroyView(view);
+                    return null;
+                });
+
+                GraphObserver observer = creation.get(60, TimeUnit.SECONDS);
+                destruction.get(60, TimeUnit.SECONDS);
+
+                Assert.assertTrue(view.isDestroyed());
+                boolean stillRegistered;
+                synchronized (view.observers) {
+                    stillRegistered = !view.observers.isEmpty();
+                }
+                Assert.assertFalse(stillRegistered, "Observer registered on a destroyed view");
+                if (observer != null) {
+                    Assert.assertTrue(observer.isDestroyed(), "Observer of a destroyed view still alive");
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/src/test/java/org/gephi/graph/impl/GraphObserverTest.java
+++ b/src/test/java/org/gephi/graph/impl/GraphObserverTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.EdgeIterable;
 import org.gephi.graph.api.Graph;
@@ -514,17 +515,25 @@ public class GraphObserverTest {
         ExecutorService executor = Executors.newFixedThreadPool(threadCount + 1);
         try {
             // Forces the version overflow path, which iterates the observers while other threads
-            // register and unregister
+            // register and unregister. Both a node and an edge are mutated so handleNodeReset()
+            // and handleEdgeReset() (each bumps a different version) both get exercised.
             Future<?> mutator = executor.submit(() -> {
                 barrier.await();
-                Node node = store.factory.newNode("concurrent-observer-test");
+                Node node1 = store.factory.newNode("concurrent-observer-test-1");
+                Node node2 = store.factory.newNode("concurrent-observer-test-2");
+                Edge edge = store.factory
+                        .newEdge("concurrent-observer-test-edge", node1, node2, EdgeTypeStore.NULL_LABEL, 1.0, true);
                 while (mutating.get()) {
                     store.autoWriteLock();
                     try {
                         store.version.nodeVersion = Integer.MAX_VALUE - 1;
                         store.version.edgeVersion = Integer.MAX_VALUE - 1;
-                        store.addNode(node);
-                        store.removeNode(node);
+                        store.addNode(node1);
+                        store.addNode(node2);
+                        store.addEdge(edge);
+                        store.removeEdge(edge);
+                        store.removeNode(node1);
+                        store.removeNode(node2);
                     } finally {
                         store.autoWriteUnlock();
                     }
@@ -556,7 +565,60 @@ public class GraphObserverTest {
             executor.shutdownNow();
         }
 
-        Assert.assertTrue(store.observers.isEmpty());
+        synchronized (store.observers) {
+            Assert.assertTrue(store.observers.isEmpty());
+        }
+    }
+
+    @Test
+    public void testConcurrentCreateAndDestroyGraphObserverAutoLockingDisabled() throws Exception {
+        final int threadCount = 4;
+        final int iterations = 500;
+
+        // With auto-locking disabled, autoWriteLock()/autoReadLock() are no-ops, so the observers
+        // list's own monitor is the only thing left guarding it against concurrent add/remove/iterate.
+        final GraphModelImpl graphModel = new GraphModelImpl(Configuration.builder().enableAutoLocking(false).build());
+        final GraphStore store = graphModel.getStore();
+        final AtomicBoolean resetting = new AtomicBoolean(true);
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount + 1);
+        try {
+            Future<?> resetter = executor.submit(() -> {
+                barrier.await();
+                while (resetting.get()) {
+                    store.version.nodeVersion = Integer.MAX_VALUE - 1;
+                    store.version.incrementAndGetNodeVersion();
+                }
+                return null;
+            });
+
+            List<Future<?>> tasks = new ArrayList<>();
+            for (int t = 0; t < threadCount; t++) {
+                tasks.add(executor.submit((Callable<Void>) () -> {
+                    barrier.await();
+                    for (int i = 0; i < iterations; i++) {
+                        GraphObserver observer = graphModel.createGraphObserver(store, false);
+                        observer.destroy();
+                        Assert.assertTrue(observer.isDestroyed());
+                    }
+                    return null;
+                }));
+            }
+
+            for (Future<?> task : tasks) {
+                task.get(60, TimeUnit.SECONDS);
+            }
+            resetting.set(false);
+            resetter.get(60, TimeUnit.SECONDS);
+        } finally {
+            resetting.set(false);
+            executor.shutdownNow();
+        }
+
+        synchronized (store.observers) {
+            Assert.assertTrue(store.observers.isEmpty());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `synchronized(observers)` guarding every access point of the `GraphStore`/`GraphViewImpl` observer lists (create, destroy, `destroyAllObservers`, version-reset iteration), so the lists stay correct even when `enableAutoLocking` is disabled and the graph's read/write lock is a no-op.
- Mark `GraphObserverImpl.destroyed` `volatile` for cross-thread visibility.
- The graph write lock around observer create/destroy in `GraphModelImpl` is kept as-is: it's what keeps view-existence checks atomic with concurrent view destruction, not just list-mutation safety — removing it (tried during development) reproducibly let an observer get registered on a view that was simultaneously being destroyed.

## Test plan
- [x] Added `testConcurrentCreateAndDestroyGraphObserver` (races observer create/destroy against forced `GraphVersion` overflow resets)
- [x] Added `testConcurrentCreateGraphObserverAndDestroyView` (races observer creation against `destroyView`)
- [x] `mvn test` — full suite passes (1647 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)